### PR TITLE
Bump rust to 1.88

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -74,15 +74,14 @@ impl ConfigV2 {
         let content = format!(
             r#"
         version = 2
-        id = "{}"
+        id = "{id}"
         backend.type = "localfs"
-        backend.localfs.dir = "{}"
+        backend.localfs.dir = "{dir}"
         cache.type = "filecache"
         cache.compressed = false
         cache.validate = false
-        cache.filecache.work_dir = "{}"
+        cache.filecache.work_dir = "{dir}"
         "#,
-            id, dir, dir
         );
 
         Self::from_str(&content)
@@ -92,10 +91,7 @@ impl ConfigV2 {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let md = fs::metadata(path.as_ref())?;
         if md.len() > 0x100000 {
-            return Err(Error::new(
-                ErrorKind::Other,
-                "configuration file size is too big",
-            ));
+            return Err(Error::other("configuration file size is too big"));
         }
         let content = fs::read_to_string(path)?;
         Self::from_str(&content)
@@ -1241,7 +1237,7 @@ impl TryFrom<&BackendConfig> for BackendConfigV2 {
             v => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    format!("unsupported backend type '{}'", v),
+                    format!("unsupported backend type '{v}'"),
                 ))
             }
         }
@@ -1307,7 +1303,7 @@ impl TryFrom<&CacheConfig> for CacheConfigV2 {
             t => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,
-                    format!("unsupported cache type '{}'", t),
+                    format!("unsupported cache type '{t}'"),
                 ))
             }
         }

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -106,7 +106,7 @@ mod tests {
 
     #[test]
     fn test_make_error() {
-        let original_error = Error::new(ErrorKind::Other, "test error");
+        let original_error = Error::other("test error");
         let debug_info = "debug information";
         let file = "test.rs";
         let line = 42;

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -147,7 +147,6 @@ pub enum MetricsErrorKind {
 }
 
 #[derive(Error, Debug)]
-#[allow(clippy::large_enum_variant)]
 pub enum ApiError {
     #[error("daemon internal error: {0:?}")]
     DaemonAbnormal(DaemonErrorKind),
@@ -158,7 +157,7 @@ pub enum ApiError {
     #[error("failed to mount filesystem: {0:?}")]
     MountFilesystem(DaemonErrorKind),
     #[error("failed to send request to the API service: {0:?}")]
-    RequestSend(#[from] SendError<Option<ApiRequest>>),
+    RequestSend(#[from] Box<SendError<Option<ApiRequest>>>),
     #[error("failed to parse response payload type")]
     ResponsePayloadType,
     #[error("failed to receive response from the API service: {0:?}")]

--- a/api/src/http_handler.rs
+++ b/api/src/http_handler.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, Result};
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender};
@@ -92,7 +92,7 @@ pub(crate) fn error_response(error: HttpError, status: StatusCode) -> Response {
     let mut response = Response::new(Version::Http11, status);
     let err_msg = ErrorMessage {
         code: "UNDEFINED".to_string(),
-        message: format!("{:?}", error),
+        message: format!("{error:?}"),
     };
     response.set_body(Body::new(err_msg));
     response
@@ -170,7 +170,9 @@ fn kick_api_server(
     from_api: &Receiver<ApiResponse>,
     request: ApiRequest,
 ) -> ApiResponse {
-    to_api.send(Some(request)).map_err(ApiError::RequestSend)?;
+    to_api
+        .send(Some(request))
+        .map_err(|err| ApiError::RequestSend(Box::new(err)))?;
     from_api.recv().map_err(ApiError::ResponseRecv)?
 }
 
@@ -250,7 +252,7 @@ pub fn start_http_thread(
         if let ServerError::IOError(e) = e {
             e
         } else {
-            Error::new(ErrorKind::Other, format!("{:?}", e))
+            Error::other(format!("{e:?}"))
         }
     })?;
     poll.registry().register(

--- a/build.rs
+++ b/build.rs
@@ -56,9 +56,9 @@ fn main() {
     let git_commit_version = get_git_commit_version();
 
     println!("cargo:rerun-if-changed=../git/HEAD");
-    println!("cargo:rustc-env=RUSTC_VERSION={}", rustc_ver);
-    println!("cargo:rustc-env=PROFILE={}", profile);
-    println!("cargo:rustc-env=BUILT_TIME_UTC={}", build_time);
-    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit_hash);
-    println!("cargo:rustc-env=GIT_COMMIT_VERSION={}", git_commit_version);
+    println!("cargo:rustc-env=RUSTC_VERSION={rustc_ver}");
+    println!("cargo:rustc-env=PROFILE={profile}");
+    println!("cargo:rustc-env=BUILT_TIME_UTC={build_time}");
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={git_commit_hash}");
+    println!("cargo:rustc-env=GIT_COMMIT_VERSION={git_commit_version}");
 }

--- a/builder/src/core/chunk_dict.rs
+++ b/builder/src/core/chunk_dict.rs
@@ -161,7 +161,7 @@ impl HashChunkDict {
         rafs_config: &RafsSuperConfig,
     ) -> Result<Self> {
         let (rs, _) = RafsSuper::load_from_file(path, config, true)
-            .with_context(|| format!("failed to open bootstrap file {:?}", path))?;
+            .with_context(|| format!("failed to open bootstrap file {path:?}"))?;
         let mut d = HashChunkDict {
             m: HashMap::new(),
             blobs: rs.superblock.get_blob_infos(),
@@ -192,8 +192,7 @@ impl HashChunkDict {
         if size % unit_size != 0 {
             return Err(std::io::Error::from_raw_os_error(libc::EINVAL)).with_context(|| {
                 format!(
-                    "load_chunk_table: invalid rafs v6 chunk table size {}",
-                    size
+                    "load_chunk_table: invalid rafs v6 chunk table size {size}"
                 )
             });
         }

--- a/builder/src/core/context.rs
+++ b/builder/src/core/context.rs
@@ -399,7 +399,7 @@ impl Artifact for ArtifactWriter {
         } else if let ArtifactStorage::SingleFile(s) = &self.storage {
             if let Ok(md) = s.metadata() {
                 if md.is_file() {
-                    remove_file(s).with_context(|| format!("failed to remove blob {:?}", s))?;
+                    remove_file(s).with_context(|| format!("failed to remove blob {s:?}"))?;
                 }
             }
         }
@@ -463,12 +463,12 @@ impl BlobCacheGenerator {
     }
 
     pub fn finalize(&self, name: &str) -> Result<()> {
-        let blob_data_name = format!("{}.blob.data", name);
+        let blob_data_name = format!("{name}.blob.data");
         let mut guard = self.blob_data.lock().unwrap();
         guard.finalize(Some(blob_data_name))?;
         drop(guard);
 
-        let blob_meta_name = format!("{}.blob.meta", name);
+        let blob_meta_name = format!("{name}.blob.meta");
         let mut guard = self.blob_meta.lock().unwrap();
         guard.finalize(Some(blob_meta_name))
     }

--- a/builder/src/core/node.rs
+++ b/builder/src/core/node.rs
@@ -1036,7 +1036,7 @@ mod tests {
             source: ChunkSource::Build,
             inner: Arc::new(chunk_wrapper1),
         };
-        println!("NodeChunk: {}", chunk);
+        println!("NodeChunk: {chunk}");
         matches!(chunk.inner.deref().clone(), ChunkWrapper::V5(_));
 
         let chunk_wrapper2 = ChunkWrapper::new(RafsVersion::V6);

--- a/builder/src/core/v6.rs
+++ b/builder/src/core/v6.rs
@@ -343,7 +343,7 @@ impl Node {
         let mut dirent_off = self.v6_dirents_offset;
         let blk_addr = ctx
             .v6_block_addr(dirent_off)
-            .with_context(|| format!("failed to compute blk_addr for offset 0x{:x}", dirent_off))?;
+            .with_context(|| format!("failed to compute blk_addr for offset 0x{dirent_off:x}"))?;
         inode.set_u(blk_addr);
         self.v6_dump_inode(ctx, f_bootstrap, inode)
             .context("failed to dump inode for directory")?;
@@ -464,8 +464,7 @@ impl Node {
             let offset = chunk.inner.uncompressed_offset();
             let blk_addr = ctx.v6_block_addr(offset).with_context(|| {
                 format!(
-                    "failed to compute blk_addr for chunk with uncompressed offset 0x{:x}",
-                    offset
+                    "failed to compute blk_addr for chunk with uncompressed offset 0x{offset:x}"
                 )
             })?;
             let blob_idx = chunk.inner.blob_index();
@@ -509,7 +508,7 @@ impl Node {
         let offset = align_offset(self.v6_offset + self.v6_size_with_xattr(), unit);
         f_bootstrap
             .seek(SeekFrom::Start(offset))
-            .with_context(|| format!("failed to seek to 0x{:x} for writing chunk data", offset))?;
+            .with_context(|| format!("failed to seek to 0x{offset:x} for writing chunk data"))?;
         f_bootstrap
             .write(chunks.as_slice())
             .context("failed to write chunk data for file")?;

--- a/builder/src/directory.rs
+++ b/builder/src/directory.rs
@@ -70,7 +70,7 @@ impl FilesystemTreeBuilder {
                 parent.info.explicit_uidgid,
                 true,
             )
-            .with_context(|| format!("failed to create node {:?}", path))?;
+            .with_context(|| format!("failed to create node {path:?}"))?;
             child.layer_idx = layer_idx;
 
             // as per OCI spec, whiteout file should not be present within final image

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -214,7 +214,7 @@ fn finalize_blob(
 
         let hash = blob_ctx.blob_hash.clone().finalize();
         let blob_meta_id = if ctx.blob_id.is_empty() {
-            format!("{:x}", hash)
+            format!("{hash:x}")
         } else {
             assert!(!ctx.conversion_type.is_to_ref() || is_tarfs);
             ctx.blob_id.clone()
@@ -402,7 +402,7 @@ mod tests {
         let node = builder.create_directory(&target_paths);
         assert!(node.is_ok());
         let node = node.unwrap();
-        println!("Node: {}", node);
+        println!("Node: {node}");
         assert_eq!(node.file_type(), "dir");
         assert_eq!(node.target(), tmp_dir.as_path());
 

--- a/builder/src/merge.rs
+++ b/builder/src/merge.rs
@@ -137,7 +137,7 @@ impl Merger {
         if let Some(parent_bootstrap_path) = &parent_bootstrap_path {
             let (rs, _) =
                 RafsSuper::load_from_file(parent_bootstrap_path, config_v2.clone(), false)
-                    .context(format!("load parent bootstrap {:?}", parent_bootstrap_path))?;
+                    .context(format!("load parent bootstrap {parent_bootstrap_path:?}"))?;
             let blobs = rs.superblock.get_blob_infos();
             for blob in &blobs {
                 let blob_ctx = BlobContext::from(ctx, &blob, ChunkSource::Parent)?;
@@ -153,7 +153,7 @@ impl Merger {
         let mut config = None;
         if let Some(chunk_dict_path) = &chunk_dict {
             let (rs, _) = RafsSuper::load_from_file(chunk_dict_path, config_v2.clone(), false)
-                .context(format!("load chunk dict bootstrap {:?}", chunk_dict_path))?;
+                .context(format!("load chunk dict bootstrap {chunk_dict_path:?}"))?;
             config = Some(rs.meta.get_config());
             for blob in rs.superblock.get_blob_infos() {
                 chunk_dict_blobs.insert(blob.blob_id().to_string());
@@ -165,7 +165,7 @@ impl Merger {
 
         for (layer_idx, bootstrap_path) in sources.iter().enumerate() {
             let (rs, _) = RafsSuper::load_from_file(bootstrap_path, config_v2.clone(), false)
-                .context(format!("load bootstrap {:?}", bootstrap_path))?;
+                .context(format!("load bootstrap {bootstrap_path:?}"))?;
             config
                 .get_or_insert_with(|| rs.meta.get_config())
                 .check_compatibility(&rs.meta)?;
@@ -434,7 +434,7 @@ mod tests {
         );
         assert!(build_output.is_ok());
         let build_output = build_output.unwrap();
-        println!("BuildOutput: {}", build_output);
+        println!("BuildOutput: {build_output}");
         assert_eq!(build_output.blob_size, Some(16));
     }
 }

--- a/builder/src/stargz.rs
+++ b/builder/src/stargz.rs
@@ -359,7 +359,7 @@ struct TocIndex {
 impl TocIndex {
     fn load(path: &Path, offset: u64) -> Result<TocIndex> {
         let mut index_file = File::open(path)
-            .with_context(|| format!("stargz: failed to open index file {:?}", path))?;
+            .with_context(|| format!("stargz: failed to open index file {path:?}"))?;
         let pos = index_file
             .seek(SeekFrom::Start(offset))
             .context("stargz: failed to seek to start of TOC")?;
@@ -368,8 +368,7 @@ impl TocIndex {
         }
         let mut toc_index: TocIndex = serde_json::from_reader(index_file).with_context(|| {
             format!(
-                "stargz: failed to deserialize stargz TOC index file {:?}",
-                path
+                "stargz: failed to deserialize stargz TOC index file {path:?}"
             )
         })?;
 
@@ -627,8 +626,7 @@ impl StargzBuilder {
                     .decode(value)
                     .with_context(|| {
                         format!(
-                            "stargz: failed to parse xattr {:?} for entry {:?}",
-                            path, name
+                            "stargz: failed to parse xattr {path:?} for entry {name:?}"
                         )
                     })?;
                 xattrs.add(OsString::from(name), value)?;

--- a/clib/src/fs.rs
+++ b/clib/src/fs.rs
@@ -63,12 +63,11 @@ fn default_localfs_rafs_config(dir: &str) -> String {
         [backend]
         type = "localfs"
         [backend.localfs]
-        dir = "{}"
+        dir = "{dir}"
         [cache]
         type = "dummycache"
         [rafs]
-        "#,
-        dir
+        "#
     )
 }
 

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -383,7 +383,7 @@ impl RafsInode for CachedInodeV5 {
             if !self.has_hole() && chunks != self.i_data.len() as u64 {
                 return Err(einval!("invalid chunk count"));
             }
-            let blocks = (self.i_size + 511) / 512;
+            let blocks = self.i_size.div_ceil(512);
             // Old stargz builder generates inode with 0 blocks
             if blocks != self.i_blocks && self.i_blocks != 0 {
                 return Err(einval!("invalid block count"));
@@ -1998,9 +1998,7 @@ mod cached_tests {
             let curr_name = &root_dir.i_child[i].i_name;
             assert!(
                 prev_name <= curr_name,
-                "Children not sorted: {:?} > {:?}",
-                prev_name,
-                curr_name
+                "Children not sorted: {prev_name:?} > {curr_name:?}"
             );
         }
 

--- a/rafs/src/metadata/chunk.rs
+++ b/rafs/src/metadata/chunk.rs
@@ -34,11 +34,11 @@ pub enum ChunkWrapper {
 impl Debug for ChunkWrapper {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::V5(c) => write!(f, "{:?}", c),
-            Self::V6(c) => write!(f, "{:?}", c),
+            Self::V5(c) => write!(f, "{c:?}"),
+            Self::V6(c) => write!(f, "{c:?}"),
             Self::Ref(c) => {
                 let chunk = to_rafs_v5_chunk_info(as_blob_v5_chunk_info(c.deref()));
-                write!(f, "{:?}", chunk)
+                write!(f, "{chunk:?}")
             }
         }
     }
@@ -63,7 +63,7 @@ impl Display for ChunkWrapper {
         } else {
             base_format
         };
-        write!(f, "{}", full_format)
+        write!(f, "{full_format}")
     }
 }
 
@@ -693,7 +693,7 @@ mod tests {
     fn test_fmt() {
         let wrapper_v5 = ChunkWrapper::Ref(Arc::new(CachedChunkInfoV5::default()));
         assert_eq!(
-            format!("{:?}", wrapper_v5),
+            format!("{wrapper_v5:?}"),
             "RafsV5ChunkInfo { block_id: RafsDigest { data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] }, blob_index: 0, flags: (empty), compressed_size: 0, uncompressed_size: 0, compressed_offset: 0, uncompressed_offset: 0, file_offset: 0, index: 0, crc32: 0 }"
         );
     }

--- a/rafs/src/metadata/inode.rs
+++ b/rafs/src/metadata/inode.rs
@@ -35,11 +35,11 @@ pub enum InodeWrapper {
 impl Debug for InodeWrapper {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::V5(i) => write!(f, "{:?}", i),
-            Self::V6(i) => write!(f, "{:?}", i),
+            Self::V5(i) => write!(f, "{i:?}"),
+            Self::V6(i) => write!(f, "{i:?}"),
             Self::Ref(i) => {
                 let i = RafsV5Inode::from(i.deref());
-                write!(f, "{:?}", i)
+                write!(f, "{i:?}")
             }
         }
     }

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1871,7 +1871,7 @@ impl RafsV6BlobTable {
             return Ok(());
         }
         if blob_table_size as usize % size_of::<RafsV6Blob>() != 0 {
-            let msg = format!("invalid Rafs v6 blob table size {}", blob_table_size);
+            let msg = format!("invalid Rafs v6 blob table size {blob_table_size}");
             return Err(einval!(msg));
         }
 

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -11,7 +11,7 @@ use std::convert::{TryFrom, TryInto};
 use std::ffi::{OsStr, OsString};
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::fs::OpenOptions;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, Result};
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
@@ -324,7 +324,7 @@ impl Default for RafsSuperFlags {
 
 impl Display for RafsSuperFlags {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
-        write!(f, "{:?}", self)?;
+        write!(f, "{self:?}")?;
         Ok(())
     }
 }
@@ -824,7 +824,7 @@ impl RafsSuper {
             return Ok(());
         }
 
-        Err(Error::new(ErrorKind::Other, "invalid RAFS superblock"))
+        Err(Error::other("invalid RAFS superblock"))
     }
 
     /// Set meta blob file path from which the `RafsSuper` object is loaded from.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.88.0"
 components = ["rustfmt", "clippy"]

--- a/service/src/blob_cache.rs
+++ b/service/src/blob_cache.rs
@@ -31,7 +31,7 @@ pub fn generate_blob_key(domain_id: &str, blob_id: &str) -> String {
     if domain_id.is_empty() {
         blob_id.to_string()
     } else {
-        format!("{}{}{}", domain_id, ID_SPLITTER, blob_id)
+        format!("{domain_id}{ID_SPLITTER}{blob_id}")
     }
 }
 

--- a/service/src/block_device.rs
+++ b/service/src/block_device.rs
@@ -118,22 +118,19 @@ impl BlockDevice {
                 .get_blob_extra_info(&blob_id)
                 .ok_or_else(|| {
                     let msg = format!(
-                        "block_device: can not get extra information for blob {}",
-                        blob_id
+                        "block_device: can not get extra information for blob {blob_id}"
                     );
                     enoent!(msg)
                 })?;
             if extra_info.mapped_blkaddr == 0 {
                 let msg = format!(
-                    "block_device: mapped block address for blob {} is zero",
-                    blob_id
+                    "block_device: mapped block address for blob {blob_id} is zero"
                 );
                 return Err(einval!(msg));
             }
             if is_tarfs_mode != blob_info.features().is_tarfs() {
                 let msg = format!(
-                    "block_device: inconsistent `TARFS` mode from meta and data blob {}",
-                    blob_id
+                    "block_device: inconsistent `TARFS` mode from meta and data blob {blob_id}"
                 );
                 return Err(einval!(msg));
             }
@@ -464,7 +461,7 @@ impl BlockDevice {
             let root_digest: String = root_digest
                 .data
                 .iter()
-                .fold(String::new(), |acc, v| acc + &format!("{:02x}", v));
+                .fold(String::new(), |acc, v| acc + &format!("{v:02x}"));
             println!(
                 "dm-verity options: --no-superblock --format=1 -s \"\" --hash=sha256 --data-block-size={} --hash-block-size=4096 --data-blocks {} --hash-offset {} {}",
                 block_device.block_size(), blocks, verity_offset, root_digest

--- a/service/src/daemon.rs
+++ b/service/src/daemon.rs
@@ -39,7 +39,7 @@ pub enum DaemonState {
 
 impl Display for DaemonState {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/service/src/fs_cache.rs
+++ b/service/src/fs_cache.rs
@@ -302,10 +302,10 @@ impl FsCacheHandler {
 
         if restore_file.is_none() {
             // Initialize the fscache session
-            file.write_all(format!("dir {}", dir).as_bytes())?;
+            file.write_all(format!("dir {dir}").as_bytes())?;
             file.flush()?;
             if let Some(tag) = tag {
-                file.write_all(format!("tag {}", tag).as_bytes())?;
+                file.write_all(format!("tag {tag}").as_bytes())?;
                 file.flush()?;
             }
             file.write_all(b"bind ondemand")?;
@@ -828,7 +828,7 @@ impl FsCacheHandler {
 
     #[inline]
     fn round_up_u32(&self, size: usize) -> usize {
-        (size + 3) / 4 * 4
+        size.div_ceil(4) * 4
     }
 
     //address from kernel fscache_hash()
@@ -874,13 +874,13 @@ impl FsCacheHandler {
         let dir_hash = self.fscache_hash(volume_hash, cookie_hash_key.as_slice());
 
         let dir = format!("@{:02x}", dir_hash as u8);
-        let cookie = format!("D{}", cookie_key);
+        let cookie = format!("D{cookie_key}");
         (volume_path.join(dir), cookie)
     }
 
     fn inuse(&self, cookie_dir: &Path, cookie_name: &str) -> Result<bool> {
         env::set_current_dir(cookie_dir)?;
-        let msg = format!("inuse {}", cookie_name);
+        let msg = format!("inuse {cookie_name}");
         let ret = unsafe {
             libc::write(
                 self.file.as_raw_fd(),
@@ -903,7 +903,7 @@ impl FsCacheHandler {
 
     fn cull(&self, cookie_dir: &Path, cookie_name: &str) -> Result<()> {
         env::set_current_dir(cookie_dir)?;
-        let msg = format!("cull {}", cookie_name);
+        let msg = format!("cull {cookie_name}");
         let ret = unsafe {
             libc::write(
                 self.file.as_raw_fd(),

--- a/service/src/fs_service.rs
+++ b/service/src/fs_service.rs
@@ -66,7 +66,7 @@ impl FsBackendCollection {
         let fs_config = match cmd.fs_type {
             FsBackendType::Rafs => {
                 let cfg = ConfigV2::from_str(&cmd.config)
-                    .map_err(|e| Error::InvalidConfig(format!("{}", e)))?;
+                    .map_err(|e| Error::InvalidConfig(format!("{e}")))?;
                 let cfg = cfg.clone_without_secrets();
                 Some(cfg)
             }
@@ -313,7 +313,7 @@ fn fs_backend_factory(cmd: &FsBackendMountCmd) -> Result<BackFileSystem> {
                             | FsOptions::ZERO_MESSAGE_OPENDIR;
 
                         let passthrough_fs = PassthroughFs::<()>::new(fs_cfg)
-                            .map_err(|e| Error::InvalidConfig(format!("{}", e)))?;
+                            .map_err(|e| Error::InvalidConfig(format!("{e}")))?;
                         passthrough_fs.init(fsopts).map_err(Error::PassthroughFs)?;
 
                         type BoxedLayer = Box<dyn Layer<Inode = u64, Handle = u64> + Send + Sync>;
@@ -332,7 +332,7 @@ fn fs_backend_factory(cmd: &FsBackendMountCmd) -> Result<BackFileSystem> {
                         };
                         let overlayfs =
                             OverlayFs::new(Some(upper_layer), lower_layers, overlay_config)
-                                .map_err(|e| Error::InvalidConfig(format!("{}", e)))?;
+                                .map_err(|e| Error::InvalidConfig(format!("{e}")))?;
                         info!(
                             "init overlay fs inode, upper {}, work {}\n",
                             ovl_conf.upper_dir.clone(),
@@ -340,7 +340,7 @@ fn fs_backend_factory(cmd: &FsBackendMountCmd) -> Result<BackFileSystem> {
                         );
                         overlayfs
                             .import()
-                            .map_err(|e| Error::InvalidConfig(format!("{}", e)))?;
+                            .map_err(|e| Error::InvalidConfig(format!("{e}")))?;
                         info!("Overlay filesystem imported");
                         Ok(Box::new(overlayfs))
                     }

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -10,7 +10,7 @@ use nydus_rafs::metadata::{RafsInode, RafsInodeWalkAction};
 use std::any::Any;
 use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fs::metadata;
-use std::io::{Error, ErrorKind, Result, Write};
+use std::io::{Error, Result, Write};
 use std::ops::Deref;
 #[cfg(target_os = "linux")]
 use std::os::linux::fs::MetadataExt;
@@ -120,9 +120,8 @@ impl FuseServer {
 
         loop {
             if let Some((reader, writer)) = self.ch.get_request().map_err(|e| {
-                Error::new(
-                    ErrorKind::Other,
-                    format!("failed to get fuse request from /dev/fuse, {}", e),
+                Error::other(
+                    format!("failed to get fuse request from /dev/fuse, {e}"),
                 )
             })? {
                 if let Err(e) =
@@ -525,7 +524,7 @@ impl NydusDaemon for FusedevDaemon {
         for _ in 0..self.threads_cnt {
             let waker = self.waker.clone();
             self.kick_one_server(waker)
-                .map_err(|e| NydusError::StartService(format!("{}", e)))?;
+                .map_err(|e| NydusError::StartService(format!("{e}")))?;
         }
 
         Ok(())

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -140,11 +140,11 @@ impl From<Error> for DaemonErrorKind {
     fn from(e: Error) -> Self {
         use Error::*;
         match e {
-            UpgradeManager(e) => DaemonErrorKind::UpgradeManager(format!("{:?}", e)),
+            UpgradeManager(e) => DaemonErrorKind::UpgradeManager(format!("{e:?}")),
             NotReady => DaemonErrorKind::NotReady,
             Unsupported => DaemonErrorKind::Unsupported,
             Serde(e) => DaemonErrorKind::Serde(e),
-            UnexpectedEvent(e) => DaemonErrorKind::UnexpectedEvent(format!("{:?}", e)),
+            UnexpectedEvent(e) => DaemonErrorKind::UnexpectedEvent(format!("{e:?}")),
             o => DaemonErrorKind::Other(o.to_string()),
         }
     }
@@ -184,8 +184,7 @@ impl FromStr for FsBackendType {
             "passthroughfs" => Ok(FsBackendType::PassthroughFs),
             "passthrough_fs" => Ok(FsBackendType::PassthroughFs),
             o => Err(Error::InvalidArguments(format!(
-                "only 'rafs' and 'passthrough_fs' are supported, but {} was specified",
-                o
+                "only 'rafs' and 'passthrough_fs' are supported, but {o} was specified"
             ))),
         }
     }
@@ -193,7 +192,7 @@ impl FromStr for FsBackendType {
 
 impl Display for FsBackendType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -217,8 +216,7 @@ pub fn validate_threads_configuration<V: AsRef<str>>(v: V) -> std::result::Resul
             Ok(t)
         } else {
             Err(format!(
-                "invalid thread number {}, valid range: [1-1024]",
-                t
+                "invalid thread number {t}, valid range: [1-1024]"
             ))
         }
     } else {

--- a/service/src/singleton.rs
+++ b/service/src/singleton.rs
@@ -187,7 +187,7 @@ impl NydusDaemon for ServiceController {
 
     fn start(&self) -> Result<()> {
         self.start_services()
-            .map_err(|e| Error::StartService(format!("{}", e)))
+            .map_err(|e| Error::StartService(format!("{e}")))
     }
 
     fn umount(&self) -> Result<()> {
@@ -235,7 +235,7 @@ impl NydusDaemon for ServiceController {
             if let Some(fscache) = self.fscache.lock().unwrap().clone() {
                 return fscache
                     .cull_cache(_blob_id)
-                    .map_err(|e| Error::StartService(format!("{}", e)));
+                    .map_err(|e| Error::StartService(format!("{e}")));
             }
         }
         Err(Error::Unsupported)

--- a/service/src/upgrade.rs
+++ b/service/src/upgrade.rs
@@ -163,9 +163,8 @@ impl UpgradeManager {
 
     pub fn save_vfs_stat(&mut self, vfs: &Vfs) -> Result<()> {
         let vfs_state_data = vfs.save_to_bytes().map_err(|e| {
-            let io_err = io::Error::new(
-                io::ErrorKind::Other,
-                format!("Failed to save vfs state: {:?}", e),
+            let io_err = io::Error::other(
+                format!("Failed to save vfs state: {e:?}"),
             );
             UpgradeMgrError::Serialize(io_err)
         })?;

--- a/src/bin/nydus-image/deduplicate.rs
+++ b/src/bin/nydus-image/deduplicate.rs
@@ -33,7 +33,7 @@ impl std::fmt::Display for DatabaseError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match *self {
             DatabaseError::SqliteError(ref err) => err.fmt(f),
-            DatabaseError::PoisonError(ref err) => write!(f, "PoisonError: {}", err),
+            DatabaseError::PoisonError(ref err) => write!(f, "PoisonError: {err}"),
             // Add other error type formatting here.
         }
     }
@@ -171,7 +171,7 @@ pub fn check_bootstrap_versions_consistency(
         ctx.fs_version = first_version;
         if versions.iter().any(|(_, v)| *v != first_version) {
             for (path, version) in &versions {
-                println!("Bootstrap path {:?} has version {:?}", path, version);
+                println!("Bootstrap path {path:?} has version {version:?}");
             }
             return Err(anyhow!(
                 "Bootstrap versions are inconsistent, cannot use chunkdict."
@@ -1466,7 +1466,7 @@ mod tests {
         blob_table.create()?;
         for i in 0..200 {
             let blob = ChunkdictBlobInfo {
-                blob_id: format!("BLOB{}", i),
+                blob_id: format!("BLOB{i}"),
                 blob_compressed_size: i,
                 blob_uncompressed_size: i * 2,
                 blob_compressor: "zstd".to_string(),
@@ -1495,10 +1495,10 @@ mod tests {
         for i in 0..200 {
             let i64 = i as u64;
             let chunk = ChunkdictChunkInfo {
-                image_reference: format!("REDIS{}", i),
-                version: format!("1.0.0{}", i),
-                chunk_blob_id: format!("BLOB{}", i),
-                chunk_digest: format!("DIGEST{}", i),
+                image_reference: format!("REDIS{i}"),
+                version: format!("1.0.0{i}"),
+                chunk_blob_id: format!("BLOB{i}"),
+                chunk_digest: format!("DIGEST{i}"),
                 chunk_crc32: i,
                 chunk_compressed_size: i,
                 chunk_uncompressed_size: i * 2,
@@ -1529,7 +1529,7 @@ mod tests {
             let chunk = ChunkdictChunkInfo {
                 image_reference: format!("REDIS{}", 0),
                 version: format!("1.0.0{}", (i + 1) / 100),
-                chunk_blob_id: format!("BLOB{}", i),
+                chunk_blob_id: format!("BLOB{i}"),
                 chunk_digest: format!("DIGEST{}", (i + 1) % 2),
                 chunk_crc32: i,
                 chunk_compressed_size: i,
@@ -1562,7 +1562,7 @@ mod tests {
             let chunk = ChunkdictChunkInfo {
                 image_reference: format!("REDIS{}", i / 50),
                 version: format!("1.0.0{}", (i + 1) / 100),
-                chunk_blob_id: format!("BLOB{}", i),
+                chunk_blob_id: format!("BLOB{i}"),
                 chunk_digest: format!("DIGEST{}", (i + 1) % 2),
                 chunk_crc32: i,
                 chunk_compressed_size: i,
@@ -1592,7 +1592,7 @@ mod tests {
             let chunk = ChunkdictChunkInfo {
                 image_reference: format!("REDIS{}", 0),
                 version: format!("1.0.0{}", (i + 1) / 100),
-                chunk_blob_id: format!("BLOB{}", i),
+                chunk_blob_id: format!("BLOB{i}"),
                 chunk_digest: format!("DIGEST{}", (i + 1) % 4),
                 chunk_crc32: i,
                 chunk_compressed_size: 1,
@@ -1608,7 +1608,7 @@ mod tests {
             let chunk = ChunkdictChunkInfo {
                 image_reference: format!("REDIS{}", 1),
                 version: format!("1.0.0{}", (i + 1) / 100),
-                chunk_blob_id: format!("BLOB{}", i),
+                chunk_blob_id: format!("BLOB{i}"),
                 chunk_digest: format!("DIGEST{}", (i + 1) % 4),
                 chunk_crc32: i,
                 chunk_compressed_size: 1,
@@ -1635,9 +1635,9 @@ mod tests {
         for i in 0..200 {
             for j in 0..100 {
                 let chunk = ChunkdictChunkInfo {
-                    image_reference: format!("REDIS{}", i),
+                    image_reference: format!("REDIS{i}"),
                     version: format!("1.0.0{}", j / 10),
-                    chunk_blob_id: format!("BLOB{}", j),
+                    chunk_blob_id: format!("BLOB{j}"),
                     chunk_digest: format!("DIGEST{}", j + (i / 100) * 100),
                     chunk_crc32: j,
                     chunk_compressed_size: 1,
@@ -1666,9 +1666,9 @@ mod tests {
         for i in 0..200 {
             for j in 0..100 {
                 let chunk = ChunkdictChunkInfo {
-                    image_reference: format!("REDIS{}", i),
+                    image_reference: format!("REDIS{i}"),
                     version: format!("1.0.0{}", j / 10),
-                    chunk_blob_id: format!("BLOB{}", j),
+                    chunk_blob_id: format!("BLOB{j}"),
                     chunk_digest: format!("DIGEST{}", j + (i / 100) * 100),
                     chunk_crc32: j,
                     chunk_compressed_size: 1,
@@ -1702,9 +1702,9 @@ mod tests {
         for i in 0..200 {
             for j in 0..100 {
                 let chunk = ChunkdictChunkInfo {
-                    image_reference: format!("REDIS{}", i),
+                    image_reference: format!("REDIS{i}"),
                     version: format!("1.0.0{}", (j + 1) / 100),
-                    chunk_blob_id: format!("BLOB{}", j),
+                    chunk_blob_id: format!("BLOB{j}"),
                     chunk_digest: format!("DIGEST{}", j + (i / 100) * 100),
                     chunk_crc32: j,
                     chunk_compressed_size: 1,
@@ -1729,9 +1729,9 @@ mod tests {
         for i in 0..200 {
             for j in 0..100 {
                 let chunk = ChunkdictChunkInfo {
-                    image_reference: format!("REDIS{}", i),
+                    image_reference: format!("REDIS{i}"),
                     version: format!("1.0.0{}", j / 10),
-                    chunk_blob_id: format!("BLOB{}", j),
+                    chunk_blob_id: format!("BLOB{j}"),
                     chunk_digest: format!("DIGEST{}", j + (i / 100) * 100),
                     chunk_crc32: j,
                     chunk_compressed_size: 1,
@@ -1768,7 +1768,7 @@ mod tests {
             let chunk = ChunkdictChunkInfo {
                 image_reference: format!("REDIS{}", 0),
                 version: format!("1.0.0{}", (i + 1) / 20),
-                chunk_blob_id: format!("BLOB{}", i),
+                chunk_blob_id: format!("BLOB{i}"),
                 chunk_digest: format!("DIGEST{}", (i + 1) % 2),
                 chunk_crc32: i,
                 chunk_compressed_size: i,

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -6,7 +6,7 @@ use std::{
     collections::BTreeMap,
     ffi::OsString,
     fs::Permissions,
-    io::{Error, ErrorKind, Write},
+    io::{Error, Write},
     ops::DerefMut,
     os::unix::prelude::PermissionsExt,
     path::{Path, PathBuf},
@@ -138,10 +138,7 @@ impl RafsInspector {
             };
 
             println!(
-                r#"{}    {inode_number:<8} {name:?}"#,
-                sign,
-                name = f,
-                inode_number = ino,
+                r#"{sign}    {ino:<8} {f:?}"#,
             );
 
             Ok(RafsInodeWalkAction::Continue)
@@ -188,7 +185,7 @@ impl RafsInspector {
             self.parent_inodes.push(self.cur_dir_ino);
             self.cur_dir_ino = n;
         } else {
-            println!("{} is {}", dir_name, err);
+            println!("{dir_name} is {err}");
         }
 
         Ok(None)
@@ -213,7 +210,7 @@ impl RafsInspector {
                 if let Err(e) =
                     self.stat_single_file(Some(dir_inode.as_ref()), child_inode.as_ref())
                 {
-                    return Err(Error::new(ErrorKind::Other, e));
+                    return Err(Error::other(e));
                 }
 
                 let child_inode = dir_inode.get_child_by_name(&child_name)?;
@@ -715,7 +712,7 @@ impl Executor {
                 inspector.cmd_check_inode(ino)
             }
             (cmd, _) => {
-                println!("Unsupported command: {}", cmd);
+                println!("Unsupported command: {cmd}");
                 {
                     Self::usage();
                     return Err(ExecuteError::IllegalCommand);
@@ -760,7 +757,7 @@ impl Prompt {
                 Err(ExecuteError::IllegalCommand) => continue,
                 Err(ExecuteError::HelpCommand) => continue,
                 Err(ExecuteError::ExecError(e)) => {
-                    println!("Failed to execute command, {:?}", e);
+                    println!("Failed to execute command, {e:?}");
                     continue;
                 }
                 Ok(Some(o)) => {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -957,7 +957,7 @@ fn main() -> Result<()> {
                 &build_info,
             ),
             _ => {
-                println!("{}", usage);
+                println!("{usage}");
                 Ok(())
             }
         }
@@ -987,7 +987,7 @@ fn main() -> Result<()> {
         if let Some(matches) = cmd.subcommand_matches("export") {
             Command::export(&cmd, matches, &build_info)
         } else {
-            println!("{}", usage);
+            println!("{usage}");
             Ok(())
         }
         #[cfg(not(target_os = "linux"))]
@@ -1687,7 +1687,7 @@ impl Command {
                     alt_dirs: Default::default(),
                 };
                 let local_fs = LocalFs::new(&local_fs_conf, Some("unpacker"))
-                    .with_context(|| format!("fail to create local backend for {:?}", blob_path))?;
+                    .with_context(|| format!("fail to create local backend for {blob_path:?}"))?;
 
                 (Arc::new(ConfigV2::default()), Arc::new(local_fs))
             } else {
@@ -1720,7 +1720,7 @@ impl Command {
         let mut validator = Validator::new(bootstrap_path, config)?;
         let (blobs, compressor, fs_version) = validator
             .check(verbose)
-            .with_context(|| format!("failed to check bootstrap {:?}", bootstrap_path))?;
+            .with_context(|| format!("failed to check bootstrap {bootstrap_path:?}"))?;
 
         println!("RAFS filesystem metadata is valid, referenced data blobs: ");
         let mut blob_ids = Vec::new();
@@ -2049,7 +2049,7 @@ impl Command {
             let content =
                 if let Some(backend_file) = matches.get_one::<String>("backend-config-file") {
                     fs::read_to_string(backend_file).with_context(|| {
-                        format!("fail to read backend config file {:?}", backend_file)
+                        format!("fail to read backend config file {backend_file:?}")
                     })?
                 } else if let Some(backend_config) = matches.get_one::<String>("backend-config") {
                     backend_config.clone()
@@ -2096,7 +2096,7 @@ impl Command {
             Some(v) => {
                 let param = v.trim_start_matches("0x").trim_start_matches("0X");
                 let size = u64::from_str_radix(param, 16)
-                    .context(format!("invalid blob data size {}", v))?;
+                    .context(format!("invalid blob data size {v}"))?;
                 Ok(size)
             }
         }
@@ -2113,10 +2113,10 @@ impl Command {
             }
             Some(v) => {
                 let chunk_size = if v.starts_with("0x") || v.starts_with("0X") {
-                    u32::from_str_radix(&v[2..], 16).context(format!("invalid chunk size {}", v))?
+                    u32::from_str_radix(&v[2..], 16).context(format!("invalid chunk size {v}"))?
                 } else {
                     v.parse::<u32>()
-                        .context(format!("invalid chunk size {}", v))?
+                        .context(format!("invalid chunk size {v}"))?
                 };
                 if chunk_size as u64 > RAFS_MAX_CHUNK_SIZE
                     || chunk_size < 0x1000
@@ -2139,10 +2139,10 @@ impl Command {
             None => Ok(0),
             Some(v) => {
                 let batch_size = if v.starts_with("0x") || v.starts_with("0X") {
-                    u32::from_str_radix(&v[2..], 16).context(format!("invalid batch size {}", v))?
+                    u32::from_str_radix(&v[2..], 16).context(format!("invalid batch size {v}"))?
                 } else {
                     v.parse::<u32>()
-                        .context(format!("invalid batch size {}", v))?
+                        .context(format!("invalid batch size {v}"))?
                 };
                 if batch_size > 0 {
                     if version.is_v5() {
@@ -2189,7 +2189,7 @@ impl Command {
             None => Ok(0),
             Some(v) => v
                 .parse::<u64>()
-                .context(format!("invalid blob offset {}", v)),
+                .context(format!("invalid blob offset {v}")),
         }
     }
 
@@ -2197,7 +2197,7 @@ impl Command {
         match matches.get_one::<String>("fs-version") {
             None => Ok(RafsVersion::V6),
             Some(v) => {
-                let version: u32 = v.parse().context(format!("invalid fs-version: {}", v))?;
+                let version: u32 = v.parse().context(format!("invalid fs-version: {v}"))?;
                 if version == 5 {
                     Ok(RafsVersion::V5)
                 } else if version == 6 {
@@ -2263,19 +2263,18 @@ impl Command {
                     "backend": {{
                         "type": "localfs",
                         "localfs": {{
-                            "dir": "{}"
+                            "dir": "{dir}"
                         }}
                     }},
                     "cache": {{
                         "type": "filecache",
                         "filecache": {{
-                            "work_dir": "{}"
+                            "work_dir": "{dir}"
                         }}
                     }},
-                    "metadata_path": "{}"
+                    "metadata_path": "{bootstrap}"
                 }}
-            }}"#,
-                dir, dir, bootstrap
+            }}"#
             );
             localfs_dir = Some(dir.to_string());
             nydus_api::BlobCacheEntry::from_str(&config)?

--- a/src/bin/nydus-image/stat.rs
+++ b/src/bin/nydus-image/stat.rs
@@ -282,7 +282,7 @@ impl ImageStat {
             .create(true)
             .write(true)
             .open(path)
-            .with_context(|| format!("Output file {:?} can't be opened", path))?;
+            .with_context(|| format!("Output file {path:?} can't be opened"))?;
 
         serde_json::to_writer(w, self).context("Write output file failed")?;
 

--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -131,7 +131,7 @@ impl OCITarBuilderFactory {
                 .truncate(true)
                 .read(false)
                 .open(output_path)
-                .with_context(|| format!("fail to open output file {:?}", output_path))?,
+                .with_context(|| format!("fail to open output file {output_path:?}"))?,
         );
 
         Ok(builder)

--- a/src/bin/nydus-image/unpack/pax.rs
+++ b/src/bin/nydus-image/unpack/pax.rs
@@ -4,7 +4,7 @@ use std::{
     collections::HashMap,
     ffi::OsStr,
     io::{self, Cursor, Error, ErrorKind, Read},
-    iter::{self, repeat},
+    iter::repeat,
     os::unix::prelude::{OsStrExt, OsStringExt},
     path::{Path, PathBuf},
     rc::Rc,
@@ -575,7 +575,7 @@ impl PAXUtil {
 
         header
             .set_link_name(&path)
-            .with_context(|| format!("fail to set header link again for {:?}", path))?;
+            .with_context(|| format!("fail to set header link again for {path:?}"))?;
 
         Ok(Some(extension))
     }
@@ -601,7 +601,7 @@ impl PAXUtil {
 
         header
             .set_path(&path)
-            .with_context(|| format!("fail to set header path again for {:?}", path))?;
+            .with_context(|| format!("fail to set header path again for {path:?}"))?;
 
         Ok(Some(extension))
     }
@@ -682,7 +682,7 @@ impl Util {
         let bs = header.as_bytes();
         let sum = bs[0..offset]
             .iter()
-            .chain(iter::repeat(&b' ').take(len))
+            .chain(std::iter::repeat_n(&b' ', len))
             .chain(&bs[offset + len..])
             .fold(0, |a, b| a + (*b as u32));
 
@@ -690,7 +690,7 @@ impl Util {
         bs[bs.len() - 1] = b' ';
         bs[bs.len() - 2] = 0o0;
 
-        let o = format!("{:o}", sum);
+        let o = format!("{sum:o}");
         let value = o.bytes().rev().chain(repeat(b'0'));
         for (slot, value) in bs.iter_mut().rev().skip(2).zip(value) {
             *slot = value;
@@ -770,7 +770,7 @@ impl Read for ChunkReader {
                     Some(chunk) => self.load_chunk(chunk.as_ref()).map_err(|err| {
                         Error::new(
                             ErrorKind::InvalidData,
-                            format!("fail to load chunk, error: {}", err),
+                            format!("fail to load chunk, error: {err}"),
                         )
                     })?,
                 }

--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -35,9 +35,9 @@ impl Validator {
         let pre = &mut |t: &Tree| -> Result<()> {
             let node = t.borrow_mut_node();
             if verbosity {
-                println!("inode: {}", node);
+                println!("inode: {node}");
                 for chunk in &node.chunks {
-                    println!("\t chunk: {}", chunk);
+                    println!("\t chunk: {chunk}");
                 }
             }
             Ok(())

--- a/src/bin/nydusctl/client.rs
+++ b/src/bin/nydusctl/client.rs
@@ -25,7 +25,7 @@ impl NydusdClient {
     }
 
     fn build_uri(&self, path: &str, query: Option<Vec<(&str, &str)>>) -> HyperUri {
-        let mut endpoint = format!("/api/{}", path);
+        let mut endpoint = format!("/api/{path}");
 
         if let Some(q) = query {
             let mut params = String::new();
@@ -33,7 +33,7 @@ impl NydusdClient {
                 params.push_str(&format!("{}={}", p.0, p.1))
             }
 
-            endpoint.push_str(&format!("?{}", params));
+            endpoint.push_str(&format!("?{params}"));
         }
 
         Uri::new(&self.sock_path, endpoint.as_str()).into()
@@ -208,10 +208,8 @@ mod tests {
             let uri = client.build_uri(path, None);
             let uri_str = uri.to_string();
             assert!(
-                uri_str.contains(&format!("/api/{}", path)),
-                "URI should contain /api/{}, got {}",
-                path,
-                uri_str
+                uri_str.contains(&format!("/api/{path}")),
+                "URI should contain /api/{path}, got {uri_str}"
             );
         }
     }

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -65,7 +65,7 @@ impl CommandCache {
         let prefetch_data_amount = m["prefetch_data_amount"].as_f64().unwrap();
 
         if raw {
-            println!("{}", metrics);
+            println!("{metrics}");
         } else {
             print!(
                 r#"
@@ -206,7 +206,7 @@ Block Sizes/millis:
         }
 
         if raw {
-            println!("{}", metrics);
+            println!("{metrics}");
         } else {
             let sizes = ["<1K", "1K~", "4K~", "16K~", "64K~", "128K~", "512K~", "1M~"];
             let m = metrics.as_object().unwrap();
@@ -298,7 +298,7 @@ impl CommandFsStats {
         let fop_counter = m["fop_hits"].as_array().unwrap();
         let fop_errors = m["fop_errors"].as_array().unwrap();
         if raw {
-            println!("{}", metrics);
+            println!("{metrics}");
         } else {
             let periods = [
                 "<1ms", "~20ms", "~50ms", "~100ms", "~500ms", "~1s", "~2s", "2s~",
@@ -391,7 +391,7 @@ impl CommandDaemon {
             let i = info.as_object().unwrap();
 
             if raw {
-                println!("{}", info);
+                println!("{info}");
             } else {
                 let version_info = &i["version"];
                 print!(
@@ -416,7 +416,7 @@ Commit:                 {git_commit}
                         for (mount_point, backend_obj) in fs_backends {
                             let backend: FsBackendDescriptor =
                                 serde_json::from_value(backend_obj.clone()).unwrap();
-                            println!("\tInstance Mountpoint:  {}", mount_point);
+                            println!("\tInstance Mountpoint:  {mount_point}");
                             println!("\tType:  {}", backend.backend_type);
                             println!("\tMounted Time:  {}", backend.mounted_time);
                             match backend.backend_type {

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -131,7 +131,7 @@ impl ApiServer {
     }
 
     fn events() -> ApiResponse {
-        let events = metrics::export_events().map_err(|e| ApiError::Events(format!("{:?}", e)))?;
+        let events = metrics::export_events().map_err(|e| ApiError::Events(format!("{e:?}")))?;
         Ok(ApiResponsePayload::Events(events))
     }
 
@@ -276,8 +276,7 @@ impl ApiServer {
             Some(mgr) => {
                 if let Err(e) = mgr.add_blob_entry(entry) {
                     Err(ApiError::DaemonAbnormal(DaemonErrorKind::Other(format!(
-                        "{}",
-                        e
+                        "{e}"
                     ))))
                 } else {
                     if let Some(mut mgr_guard) = self.get_daemon_object()?.upgrade_mgr() {
@@ -296,8 +295,7 @@ impl ApiServer {
             Some(mgr) => {
                 if let Err(e) = mgr.remove_blob_entry(param) {
                     Err(ApiError::DaemonAbnormal(DaemonErrorKind::Other(format!(
-                        "{}",
-                        e
+                        "{e}"
                     ))))
                 } else {
                     if let Some(mut mgr_guard) = self.get_daemon_object()?.upgrade_mgr() {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -409,7 +409,7 @@ fn process_fs_service(
                 "backend": {{
                     "type": "localfs",
                     "config": {{
-                        "dir": {:?},
+                        "dir": {v:?},
                         "readahead": true
                     }}
                 }},
@@ -417,7 +417,7 @@ fn process_fs_service(
                     "type": "blobcache",
                     "config": {{
                         "compressed": false,
-                        "work_dir": {:?}
+                        "work_dir": {v:?}
                     }}
                 }}
             }},
@@ -425,8 +425,7 @@ fn process_fs_service(
             "digest_validate": false,
             "iostats_files": false
         }}
-        "###,
-                    v, v
+        "###
                 )
             }
             None => match args.value_of("config") {

--- a/src/bin/nydusd/virtiofs.rs
+++ b/src/bin/nydusd/virtiofs.rs
@@ -317,7 +317,7 @@ where
 
     fn start(&self) -> Result<()> {
         let listener =
-            Listener::new(&self.sock, true).map_err(|e| Error::StartService(format!("{}", e)))?;
+            Listener::new(&self.sock, true).map_err(|e| Error::StartService(format!("{e}")))?;
         let vu_daemon = self.daemon.clone();
         let _ = thread::Builder::new()
             .name("vhost_user_listener".to_string())
@@ -391,7 +391,7 @@ pub fn create_virtiofs_daemon(
         Arc::new(RwLock::new(VhostUserFsBackendHandler::new(vfs.clone())?)),
         GuestMemoryAtomic::new(GuestMemoryMmap::new()),
     )
-    .map_err(|e| Error::VhostUser(format!("{:?}", e)))?;
+    .map_err(|e| Error::VhostUser(format!("{e:?}")))?;
     let (trigger, events_rx) = channel::<DaemonStateMachineInput>();
     let (result_sender, result_receiver) = channel::<Result<()>>();
     let service = VirtioFsService::new(vfs);

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -107,12 +107,12 @@ pub fn setup_logging(
         let basename = path
             .file_stem()
             .ok_or_else(|| {
-                eprintln!("invalid file name input {:?}", path);
+                eprintln!("invalid file name input {path:?}");
                 einval!()
             })?
             .to_str()
             .ok_or_else(|| {
-                eprintln!("invalid file name input {:?}", path);
+                eprintln!("invalid file name input {path:?}");
                 einval!()
             })?;
         spec = spec.basename(basename);
@@ -120,7 +120,7 @@ pub fn setup_logging(
         // `flexi_logger` automatically add `.log` suffix if the file name has no extension.
         if let Some(suffix) = path.extension() {
             let suffix = suffix.to_str().ok_or_else(|| {
-                eprintln!("invalid file extension {:?}", suffix);
+                eprintln!("invalid file extension {suffix:?}");
                 einval!()
             })?;
             spec = spec.suffix(suffix);
@@ -158,7 +158,7 @@ pub fn setup_logging(
         }
 
         logger.start().map_err(|e| {
-            eprintln!("{:?}", e);
+            eprintln!("{e:?}");
             eother!(e)
         })?;
     } else {

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -48,11 +48,11 @@ impl fmt::Display for ConnectionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConnectionError::Disconnected => write!(f, "network connection disconnected"),
-            ConnectionError::ErrorWithMsg(s) => write!(f, "network error, {}", s),
-            ConnectionError::Common(e) => write!(f, "network error, {}", e),
-            ConnectionError::Format(e) => write!(f, "{}", e),
-            ConnectionError::Url(s, e) => write!(f, "failed to parse URL {}, {}", s, e),
-            ConnectionError::Scheme(s) => write!(f, "invalid scheme {}", s),
+            ConnectionError::ErrorWithMsg(s) => write!(f, "network error, {s}"),
+            ConnectionError::Common(e) => write!(f, "network error, {e}"),
+            ConnectionError::Format(e) => write!(f, "{e}"),
+            ConnectionError::Url(s, e) => write!(f, "failed to parse URL {s}, {e}"),
+            ConnectionError::Scheme(s) => write!(f, "invalid scheme {s}"),
         }
     }
 }

--- a/storage/src/backend/http_proxy.rs
+++ b/storage/src/backend/http_proxy.rs
@@ -57,29 +57,29 @@ impl fmt::Display for HttpProxyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             HttpProxyError::ParseStringToInteger(e) => {
-                write!(f, "failed to parse string to integer, {}", e)
+                write!(f, "failed to parse string to integer, {e}")
             }
             HttpProxyError::ParseContentLengthFromHeader(e) => {
-                write!(f, "failed to parse content length from header, {}", e)
+                write!(f, "failed to parse content length from header, {e}")
             }
-            HttpProxyError::LocalRequest(e) => write!(f, "failed to get response, {}", e),
-            HttpProxyError::RemoteRequest(e) => write!(f, "failed to get response, {}", e),
+            HttpProxyError::LocalRequest(e) => write!(f, "failed to get response, {e}"),
+            HttpProxyError::RemoteRequest(e) => write!(f, "failed to get response, {e}"),
             HttpProxyError::BuildTokioRuntime(e) => {
-                write!(f, "failed to build tokio runtime, {}", e)
+                write!(f, "failed to build tokio runtime, {e}")
             }
             HttpProxyError::BuildHttpRequest(e) => {
-                write!(f, "failed to build http request, {}", e)
+                write!(f, "failed to build http request, {e}")
             }
             HttpProxyError::Transport(e) => {
-                write!(f, "failed to transport remote response body, {}", e)
+                write!(f, "failed to transport remote response body, {e}")
             }
             HttpProxyError::ReadResponseBody(e) => {
-                write!(f, "failed to read response body, {}", e)
+                write!(f, "failed to read response body, {e}")
             }
-            HttpProxyError::CopyBuffer(e) => write!(f, "failed to copy buffer, {}", e),
+            HttpProxyError::CopyBuffer(e) => write!(f, "failed to copy buffer, {e}"),
             HttpProxyError::InvalidPath => write!(f, "invalid path"),
             HttpProxyError::ConstructHeader(e) => {
-                write!(f, "failed to construct request header, {}", e)
+                write!(f, "failed to construct request header, {e}")
             }
         }
     }
@@ -133,7 +133,7 @@ enum Uri {
 fn range_str_for_header(offset: u64, len: Option<usize>) -> String {
     match len {
         Some(len) => format!("bytes={}-{}", offset, offset + len as u64 - 1),
-        None => format!("bytes={}-", offset),
+        None => format!("bytes={offset}-"),
     }
 }
 
@@ -254,7 +254,7 @@ impl BlobReader for HttpProxyReader {
                     range
                         .as_str()
                         .parse()
-                        .map_err(|e| HttpProxyError::ConstructHeader(format!("{}", e)))?,
+                        .map_err(|e| HttpProxyError::ConstructHeader(format!("{e}")))?,
                 );
                 let mut resp = connection
                     .call::<&[u8]>(Method::GET, uri.as_str(), None, None, &mut headers, true)
@@ -409,13 +409,13 @@ mod tests {
             ),
             hyper::Method::GET => {
                 let range = req.headers()[http::header::RANGE].to_str().unwrap();
-                println!("range: {}", range);
+                println!("range: {range}");
                 let (start, end) = parse_range_header(range);
                 let length = match end {
                     Some(e) => e - start + 1,
                     None => CONTENT.len() as u64,
                 };
-                println!("start: {}, end: {:?}, length: {}", start, end, length);
+                println!("start: {start}, end: {end:?}, length: {length}");
                 let end = match end {
                     Some(e) => e,
                     None => (CONTENT.len() - 1) as u64,
@@ -492,8 +492,7 @@ mod tests {
         let test_list: Vec<(String, String)> = vec![
             (
                 format!(
-                    "{{\"addr\":\"{}\",\"path\":\"/namespace/<repo>/blobs\"}}",
-                    SOCKET_PATH,
+                    "{{\"addr\":\"{SOCKET_PATH}\",\"path\":\"/namespace/<repo>/blobs\"}}",
                 ),
                 "test-local-http-proxy".to_string(),
             ),
@@ -513,7 +512,7 @@ mod tests {
             let blob_size = reader
                 .blob_size()
                 .map_err(|e| {
-                    println!("blob_size() failed: {}", e);
+                    println!("blob_size() failed: {e}");
                     e
                 })
                 .unwrap();
@@ -525,7 +524,7 @@ mod tests {
             let size = reader
                 .try_read(&mut buf, 0)
                 .map_err(|e| {
-                    println!("read() range failed: {}", e);
+                    println!("read() range failed: {e}");
                     e
                 })
                 .unwrap();
@@ -538,7 +537,7 @@ mod tests {
             let size = reader
                 .try_read(&mut buf, 0)
                 .map_err(|e| {
-                    println!("read() range failed: {}", e);
+                    println!("read() range failed: {e}");
                     e
                 })
                 .unwrap();

--- a/storage/src/backend/localdisk.rs
+++ b/storage/src/backend/localdisk.rs
@@ -32,8 +32,8 @@ pub enum LocalDiskError {
 impl fmt::Display for LocalDiskError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LocalDiskError::BlobFile(s) => write!(f, "{}", s),
-            LocalDiskError::ReadBlob(s) => write!(f, "{}", s),
+            LocalDiskError::BlobFile(s) => write!(f, "{s}"),
+            LocalDiskError::ReadBlob(s) => write!(f, "{s}"),
         }
     }
 }
@@ -206,7 +206,7 @@ impl LocalDisk {
         };
 
         let device_file = self.device_file.try_clone().map_err(|e| {
-            LocalDiskError::BlobFile(format!("localdisk: can not duplicate file, {}", e))
+            LocalDiskError::BlobFile(format!("localdisk: can not duplicate file, {e}"))
         })?;
         let blob = Arc::new(LocalDiskBlob {
             blob_id: blob_id.to_string(),
@@ -218,7 +218,7 @@ impl LocalDisk {
 
         let mut table_guard = self.entries.write().unwrap();
         if table_guard.contains_key(blob_id) {
-            let msg = format!("localdisk: blob {} already exists", blob_id);
+            let msg = format!("localdisk: blob {blob_id} already exists");
             return Err(LocalDiskError::BlobFile(msg));
         }
         table_guard.insert(blob_id.to_string(), blob);
@@ -259,7 +259,7 @@ impl LocalDisk {
             }
         }
 
-        let msg = format!("localdisk: can not find such blob: {}", blob_id);
+        let msg = format!("localdisk: can not find such blob: {blob_id}");
         Err(LocalDiskError::ReadBlob(msg))
     }
 
@@ -305,7 +305,7 @@ impl LocalDisk {
                 return Err(einval!(msg));
             }
             if table_guard.contains_key(&name) {
-                let msg = format!("localdisk: blob {} already exists", name);
+                let msg = format!("localdisk: blob {name} already exists");
                 return Err(einval!(msg));
             }
 

--- a/storage/src/backend/localfs.rs
+++ b/storage/src/backend/localfs.rs
@@ -33,8 +33,8 @@ pub enum LocalFsError {
 impl fmt::Display for LocalFsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LocalFsError::BlobFile(s) => write!(f, "{}", s),
-            LocalFsError::ReadBlob(s) => write!(f, "{}", s),
+            LocalFsError::BlobFile(s) => write!(f, "{s}"),
+            LocalFsError::ReadBlob(s) => write!(f, "{s}"),
         }
     }
 }

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -76,18 +76,18 @@ pub enum BackendError {
 impl fmt::Display for BackendError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BackendError::Unsupported(s) => write!(f, "{}", s),
-            BackendError::CopyData(e) => write!(f, "failed to copy data, {}", e),
+            BackendError::Unsupported(s) => write!(f, "{s}"),
+            BackendError::CopyData(e) => write!(f, "failed to copy data, {e}"),
             #[cfg(feature = "backend-registry")]
-            BackendError::Registry(e) => write!(f, "{:?}", e),
+            BackendError::Registry(e) => write!(f, "{e:?}"),
             #[cfg(feature = "backend-localfs")]
-            BackendError::LocalFs(e) => write!(f, "{}", e),
+            BackendError::LocalFs(e) => write!(f, "{e}"),
             #[cfg(any(feature = "backend-oss", feature = "backend-s3"))]
-            BackendError::ObjectStorage(e) => write!(f, "{}", e),
+            BackendError::ObjectStorage(e) => write!(f, "{e}"),
             #[cfg(feature = "backend-localdisk")]
-            BackendError::LocalDisk(e) => write!(f, "{:?}", e),
+            BackendError::LocalDisk(e) => write!(f, "{e:?}"),
             #[cfg(feature = "backend-http-proxy")]
-            BackendError::HttpProxy(e) => write!(f, "{}", e),
+            BackendError::HttpProxy(e) => write!(f, "{e}"),
         }
     }
 }
@@ -140,7 +140,7 @@ pub trait BlobReader: Send + Sync {
                         ERROR_HOLDER
                             .lock()
                             .unwrap()
-                            .push(&format!("{:?}", err))
+                            .push(&format!("{err:?}"))
                             .unwrap_or_else(|_| error!("Failed when try to hold error"));
                         return Err(err);
                     }

--- a/storage/src/backend/object_storage.rs
+++ b/storage/src/backend/object_storage.rs
@@ -32,13 +32,13 @@ pub enum ObjectStorageError {
 impl fmt::Display for ObjectStorageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ObjectStorageError::Auth(e) => write!(f, "failed to generate auth info, {}", e),
-            ObjectStorageError::Request(e) => write!(f, "network communication error, {}", e),
+            ObjectStorageError::Auth(e) => write!(f, "failed to generate auth info, {e}"),
+            ObjectStorageError::Request(e) => write!(f, "network communication error, {e}"),
             ObjectStorageError::ConstructHeader(e) => {
-                write!(f, "failed to generate HTTP header, {}", e)
+                write!(f, "failed to generate HTTP header, {e}")
             }
-            ObjectStorageError::Transport(e) => write!(f, "network communication error, {}", e),
-            ObjectStorageError::Response(s) => write!(f, "network communication error, {}", s),
+            ObjectStorageError::Transport(e) => write!(f, "network communication error, {e}"),
+            ObjectStorageError::Response(s) => write!(f, "network communication error, {s}"),
         }
     }
 }
@@ -99,11 +99,11 @@ where
         Ok(content_length
             .to_str()
             .map_err(|err| {
-                ObjectStorageError::Response(format!("invalid content length: {:?}", err))
+                ObjectStorageError::Response(format!("invalid content length: {err:?}"))
             })?
             .parse::<u64>()
             .map_err(|err| {
-                ObjectStorageError::Response(format!("invalid content length: {:?}", err))
+                ObjectStorageError::Response(format!("invalid content length: {err:?}"))
             })?)
     }
 
@@ -112,14 +112,14 @@ where
         let (resource, url) = self.state.url(&self.blob_id, query);
         let mut headers = HeaderMap::new();
         let end_at = offset + buf.len() as u64 - 1;
-        let range = format!("bytes={}-{}", offset, end_at);
+        let range = format!("bytes={offset}-{end_at}");
 
         headers.insert(
             "Range",
             range
                 .as_str()
                 .parse()
-                .map_err(|e| ObjectStorageError::ConstructHeader(format!("{}", e)))?,
+                .map_err(|e| ObjectStorageError::ConstructHeader(format!("{e}")))?,
         );
         self.state
             .sign(Method::GET, &mut headers, resource.as_str(), url.as_str())

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -46,11 +46,11 @@ pub enum RegistryError {
 impl fmt::Display for RegistryError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RegistryError::Common(s) => write!(f, "failed to access blob from registry, {}", s),
-            RegistryError::Url(u, e) => write!(f, "failed to parse URL {}, {}", u, e),
-            RegistryError::Request(e) => write!(f, "failed to issue request, {}", e),
-            RegistryError::Scheme(s) => write!(f, "invalid scheme, {}", s),
-            RegistryError::Transport(e) => write!(f, "network transport error, {}", e),
+            RegistryError::Common(s) => write!(f, "failed to access blob from registry, {s}"),
+            RegistryError::Url(u, e) => write!(f, "failed to parse URL {u}, {e}"),
+            RegistryError::Request(e) => write!(f, "failed to issue request, {e}"),
+            RegistryError::Scheme(s) => write!(f, "invalid scheme, {s}"),
+            RegistryError::Transport(e) => write!(f, "network transport error, {e}"),
         }
     }
 }
@@ -315,7 +315,7 @@ impl RegistryState {
         if let Some(auth) = &self.auth {
             headers.insert(
                 HEADER_AUTHORIZATION,
-                format!("Basic {}", auth).parse().unwrap(),
+                format!("Basic {auth}").parse().unwrap(),
             );
         }
 
@@ -368,7 +368,7 @@ impl RegistryState {
             Auth::Basic(_) => self
                 .auth
                 .as_ref()
-                .map(|auth| format!("Basic {}", auth))
+                .map(|auth| format!("Basic {auth}"))
                 .ok_or_else(|| einval!("invalid auth config")),
             Auth::Bearer(auth) => {
                 let token = self.get_token(auth, connection)?;
@@ -638,7 +638,7 @@ impl RegistryReader {
             .map_err(|e| RegistryError::Url(url, e))?;
         let mut headers = HeaderMap::new();
         let end_at = offset + buf.len() as u64 - 1;
-        let range = format!("bytes={}-{}", offset, end_at);
+        let range = format!("bytes={offset}-{end_at}");
         headers.insert("Range", range.parse().unwrap());
 
         let mut resp;
@@ -804,10 +804,10 @@ impl BlobReader for RegistryReader {
 
             Ok(content_length
                 .to_str()
-                .map_err(|err| RegistryError::Common(format!("invalid content length: {:?}", err)))?
+                .map_err(|err| RegistryError::Common(format!("invalid content length: {err:?}")))?
                 .parse::<u64>()
                 .map_err(|err| {
-                    RegistryError::Common(format!("invalid content length: {:?}", err))
+                    RegistryError::Common(format!("invalid content length: {err:?}"))
                 })?)
         })
     }
@@ -850,7 +850,7 @@ impl Registry {
         let cached_auth = if let Some(registry_token) = registry_token {
             // Store the registry bearer token to cached_auth, prefer to
             // use the token stored in cached_auth to request registry.
-            Cache::new(format!("Bearer {}", registry_token))
+            Cache::new(format!("Bearer {registry_token}"))
         } else {
             Cache::new(String::new())
         };

--- a/storage/src/backend/s3.rs
+++ b/storage/src/backend/s3.rs
@@ -123,8 +123,7 @@ impl S3State {
         content_sha256: &str,
     ) -> String {
         let canonical_request = format!(
-            "{}\n{}\n{}\n{}\n\n{}\n{}",
-            method, uri, query_string, headers, signed_headers, content_sha256
+            "{method}\n{uri}\n{query_string}\n{headers}\n\n{signed_headers}\n{content_sha256}"
         );
         sha256_hash(canonical_request.as_bytes())
     }
@@ -323,7 +322,7 @@ mod tests {
     #[test]
     fn test_s3_state_sign() {
         let (state, resource, url) = get_test_s3_state();
-        println!("{}", url);
+        println!("{url}");
         let mut headers = HeaderMap::new();
         headers.append("Range", "bytes=5242900-".parse().unwrap());
         let result = state.sign(Method::GET, &mut headers, &resource, &url);

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -478,7 +478,7 @@ impl FileCacheEntry {
                 end -= 1;
             }
 
-            assert!(end >= start, "start 0x{:x}, end 0x{:x}", start, end);
+            assert!(end >= start, "start 0x{start:x}, end 0x{end:x}");
             if start == 0 && end == extended_chunks.len() - 1 {
                 extended_chunks
             } else {

--- a/storage/src/cache/dedup/mod.rs
+++ b/storage/src/cache/dedup/mod.rs
@@ -33,9 +33,9 @@ pub enum CasError {
 impl Display for CasError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            CasError::Io(e) => write!(f, "{}", e),
-            CasError::Db(e) => write!(f, "{}", e),
-            CasError::R2D2(e) => write!(f, "{}", e),
+            CasError::Io(e) => write!(f, "{e}"),
+            CasError::Db(e) => write!(f, "{e}"),
+            CasError::R2D2(e) => write!(f, "{e}"),
         }
     }
 }

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -156,7 +156,7 @@ impl BlobCacheMgr for FileCacheMgr {
             }
         }
 
-        self.blobs.read().unwrap().len() == 0
+        self.blobs.read().unwrap().is_empty()
     }
 
     fn backend(&self) -> &dyn BlobBackend {
@@ -275,8 +275,7 @@ impl FileCacheEntry {
                 file.set_len(cached_file_size)?;
             } else if cached_file_size != 0 && file_size != cached_file_size {
                 let msg = format!(
-                    "blob data file size doesn't match: got 0x{:x}, expect 0x{:x}",
-                    file_size, cached_file_size
+                    "blob data file size doesn't match: got 0x{file_size:x}, expect 0x{cached_file_size:x}"
                 );
                 return Err(einval!(msg));
             }
@@ -392,7 +391,7 @@ impl FileCacheEntry {
             Arc::new(BlobStateMap::from(DigestedChunkMap::new()))
         } else {
             Arc::new(BlobStateMap::from(IndexedChunkMap::new(
-                &format!("{}{}", blob_file, BLOB_DATA_FILE_SUFFIX),
+                &format!("{blob_file}{BLOB_DATA_FILE_SUFFIX}"),
                 blob_info.chunk_count(),
                 true,
             )?))
@@ -416,10 +415,9 @@ pub mod blob_cache_tests {
         let s = format!(
             r###"
         {{
-            "work_dir": {:?}
+            "work_dir": {dir:?}
         }}
         "###,
-            dir
         );
 
         let mut blob_config: FileCacheConfig = serde_json::from_str(&s).unwrap();

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -151,7 +151,7 @@ impl BlobCacheMgr for FsCacheMgr {
             }
         }
 
-        self.blobs.read().unwrap().len() == 0
+        self.blobs.read().unwrap().is_empty()
     }
 
     fn backend(&self) -> &dyn BlobBackend {
@@ -274,7 +274,7 @@ impl FileCacheEntry {
         };
 
         let chunk_map = Arc::new(BlobStateMap::from(IndexedChunkMap::new(
-            &format!("{}{}", blob_file_path, BLOB_DATA_FILE_SUFFIX),
+            &format!("{blob_file_path}{BLOB_DATA_FILE_SUFFIX}"),
             blob_info.chunk_count(),
             false,
         )?));

--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -521,10 +521,10 @@ pub(crate) mod tests {
                 .unwrap();
             if idx % skip_index == 0 {
                 if has_ready {
-                    panic!("indexed chunk map: index {} shouldn't be ready", idx);
+                    panic!("indexed chunk map: index {idx} shouldn't be ready");
                 }
             } else if !has_ready {
-                panic!("indexed chunk map: index {} should be ready", idx);
+                panic!("indexed chunk map: index {idx} should be ready");
             }
         }
     }
@@ -565,10 +565,7 @@ pub(crate) mod tests {
         iterate(&chunks, &digested_chunk_map as &dyn ChunkMap, chunk_count);
         let elapsed2 = now.elapsed().as_millis();
 
-        println!(
-            "IndexedChunkMap vs DigestedChunkMap: {}ms vs {}ms",
-            elapsed1, elapsed2
-        );
+        println!("IndexedChunkMap vs DigestedChunkMap: {elapsed1}ms vs {elapsed2}ms",);
     }
 
     #[test]

--- a/storage/src/cache/state/indexed_chunk_map.rs
+++ b/storage/src/cache/state/indexed_chunk_map.rs
@@ -35,7 +35,7 @@ pub struct IndexedChunkMap {
 impl IndexedChunkMap {
     /// Create a new instance of `IndexedChunkMap`.
     pub fn new(blob_path: &str, chunk_count: u32, persist: bool) -> Result<Self> {
-        let filename = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let filename = format!("{blob_path}.{FILE_SUFFIX}");
 
         PersistMap::open(&filename, chunk_count, true, persist).map(|map| IndexedChunkMap { map })
     }
@@ -153,7 +153,7 @@ mod tests {
 
         assert!(IndexedChunkMap::new(&blob_path, 0, false).is_err());
 
-        let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -162,8 +162,7 @@ mod tests {
             .open(&cache_path)
             .map_err(|err| {
                 einval!(format!(
-                    "failed to open/create blob chunk_map file {:?}: {:?}",
-                    cache_path, err
+                    "failed to open/create blob chunk_map file {cache_path:?}: {err:?}"
                 ))
             })
             .unwrap();
@@ -183,7 +182,7 @@ mod tests {
 
         assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
-        let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
         let _file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -219,7 +218,7 @@ mod tests {
 
         assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
-        let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
         let file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -256,7 +255,7 @@ mod tests {
 
         assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
-        let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -302,7 +301,7 @@ mod tests {
 
         assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
-        let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)

--- a/storage/src/cache/state/range_map.rs
+++ b/storage/src/cache/state/range_map.rs
@@ -25,7 +25,7 @@ pub struct BlobRangeMap {
 impl BlobRangeMap {
     /// Create a new instance of `BlobRangeMap`.
     pub fn new(blob_path: &str, count: u32, shift: u32) -> Result<Self> {
-        let filename = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let filename = format!("{blob_path}.{FILE_SUFFIX}");
         debug_assert!(shift < 64);
 
         PersistMap::open(&filename, count, true, true).map(|map| BlobRangeMap { shift, map })
@@ -33,7 +33,7 @@ impl BlobRangeMap {
 
     /// Create a new instance of `BlobRangeMap` from an existing chunk map file.
     pub fn open(blob_id: &str, workdir: &str, count: u32, shift: u32) -> Result<Self> {
-        let filename = format!("{}/{}.{}", workdir, blob_id, FILE_SUFFIX);
+        let filename = format!("{workdir}/{blob_id}.{FILE_SUFFIX}");
         debug_assert!(shift < 64);
 
         PersistMap::open(&filename, count, false, true).map(|map| BlobRangeMap { shift, map })
@@ -185,10 +185,10 @@ mod tests {
             let is_ready = map3.is_range_ready(addr, 1).unwrap();
             if idx % skip_index == 0 {
                 if is_ready {
-                    panic!("indexed chunk map: index {} shouldn't be ready", idx);
+                    panic!("indexed chunk map: index {idx} shouldn't be ready");
                 }
             } else if !is_ready {
-                panic!("indexed chunk map: index {} should be ready", idx);
+                panic!("indexed chunk map: index {idx} should be ready");
             }
         }
     }

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -200,7 +200,7 @@ impl AsyncWorkerMgr {
         for num in 0..mgr.prefetch_config.threads_count {
             let mgr2 = mgr.clone();
             let res = thread::Builder::new()
-                .name(format!("nydus_storage_worker_{}", num))
+                .name(format!("nydus_storage_worker_{num}"))
                 .spawn(move || {
                     mgr2.grow_n(1);
                     mgr2.metrics

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -51,7 +51,7 @@ lazy_static! {
                 .build();
         match runtime {
             Ok(v) => Arc::new(v),
-            Err(e) => panic!("failed to create tokio async runtime, {}", e),
+            Err(e) => panic!("failed to create tokio async runtime, {e}"),
         }
     };
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -94,8 +94,8 @@ impl Display for StorageError {
             StorageError::Timeout => write!(f, "timeout when reading data from storage backend"),
             StorageError::MemOverflow => write!(f, "memory overflow when doing storage backend IO"),
             StorageError::NotContinuous => write!(f, "address ranges are not continuous"),
-            StorageError::VolatileSlice(e) => write!(f, "{}", e),
-            StorageError::CacheIndex(e) => write!(f, "Wrong cache index {}", e),
+            StorageError::VolatileSlice(e) => write!(f, "{e}"),
+            StorageError::CacheIndex(e) => write!(f, "Wrong cache index {e}"),
         }
     }
 }

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::{Display, Formatter};
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, Result};
 use std::sync::atomic::{AtomicU8, Ordering};
 
 use crate::device::BlobFeatures;
@@ -233,8 +233,7 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
                 && self.uncompressed_size() != self.compressed_size())
             || (self.has_crc32() && self.crc32() == 0)
         {
-            return Err(Error::new(
-                ErrorKind::Other,
+            return Err(Error::other(
                 format!(
                     "invalid chunk, blob: index {}/c_size 0x{:x}/d_size 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {} batch {} zran {} encrypted {} has_crc {}, crc32 {}",
                     state.blob_index,
@@ -265,15 +264,13 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
         }
 
         if state.blob_features & BlobFeatures::ZRAN.bits() == 0 && self.is_zran() {
-            return Err(Error::new(
-                ErrorKind::Other,
+            return Err(Error::other(
                 "invalid chunk flag ZRan for non-ZRan blob",
             ));
         } else if self.is_zran() {
             let index = self.get_zran_index()? as usize;
             if index >= state.zran_info_array.len() {
-                return Err(Error::new(
-                    ErrorKind::Other,
+                return Err(Error::other(
                     format!(
                         "ZRan index {} is too big, max {}",
                         index,
@@ -286,8 +283,7 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
             if zran_offset >= ctx.out_size()
                 || zran_offset + self.uncompressed_size() > ctx.out_size()
             {
-                return Err(Error::new(
-                    ErrorKind::Other,
+                return Err(Error::other(
                     format!(
                         "ZRan range 0x{:x}/0x{:x} is invalid, should be with in 0/0x{:x}",
                         zran_offset,
@@ -300,21 +296,17 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
 
         if self.is_batch() {
             if state.blob_features & BlobFeatures::BATCH.bits() == 0 {
-                return Err(Error::new(
-                    ErrorKind::Other,
+                return Err(Error::other(
                     "invalid chunk flag Batch for non-Batch blob",
                 ));
             } else {
                 let index = self.get_batch_index()? as usize;
                 if index >= state.batch_info_array.len() {
-                    return Err(Error::new(
-                        ErrorKind::Other,
-                        format!(
-                            "Batch index {} is too big, max {}",
-                            index,
-                            state.batch_info_array.len()
-                        ),
-                    ));
+                    return Err(Error::other(format!(
+                        "Batch index {} is too big, max {}",
+                        index,
+                        state.batch_info_array.len()
+                    )));
                 }
                 let ctx = &state.batch_info_array[index];
                 if ctx.compressed_size() > ctx.uncompressed_batch_size()
@@ -322,7 +314,7 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
                         > ctx.uncompressed_batch_size()
                     || u64::MAX - self.compressed_offset() < ctx.compressed_size() as u64
                 {
-                    return Err(Error::new(ErrorKind::Other, format!(
+                    return Err(Error::other(format!(
                         "Batch Context is invalid: chunk: uncompressed_size 0x{:x}, uncompressed_offset_in_batch_buf 0x{:x}, uncompressed_batch_size 0x{:x}, batch context: index {}, compressed_size 0x{:x}, uncompressed_batch_size 0x{:x}",
                         self.uncompressed_size(),
                         self.get_uncompressed_offset_in_batch_buf()?,
@@ -506,7 +498,7 @@ mod tests {
     fn test_chunk_on_disk_validate() {
         let mut ctx = BlobCompressionContext::default();
         let mut chunk = BlobChunkInfoV2Ondisk::default();
-        println!("{}", chunk);
+        println!("{chunk}");
 
         chunk.set_compressed_offset(0x10);
         chunk.set_compressed_size(0x20);

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -412,7 +412,7 @@ impl BlobCompressionContextInfo {
         }
 
         let uncompressed_size = blob_info.meta_ci_uncompressed_size() as usize;
-        let meta_path = format!("{}.{}", blob_path, BLOB_CCT_FILE_SUFFIX);
+        let meta_path = format!("{blob_path}.{BLOB_CCT_FILE_SUFFIX}");
         trace!(
             "try to open blob meta file: path {:?} uncompressed_size {} chunk_count {}",
             meta_path,
@@ -527,9 +527,9 @@ impl BlobCompressionContextInfo {
         }
 
         if load_chunk_digest && blob_info.has_feature(BlobFeatures::INLINED_CHUNK_DIGEST) {
-            let digest_path = PathBuf::from(format!("{}.{}", blob_path, BLOB_DIGEST_FILE_SUFFIX));
+            let digest_path = PathBuf::from(format!("{blob_path}.{BLOB_DIGEST_FILE_SUFFIX}"));
             if let Some(reader) = reader {
-                let toc_path = format!("{}.{}", blob_path, BLOB_TOC_FILE_SUFFIX);
+                let toc_path = format!("{blob_path}.{BLOB_TOC_FILE_SUFFIX}");
                 let location = if blob_info.blob_toc_size() != 0 {
                     let blob_size = reader
                         .blob_size()
@@ -1732,8 +1732,7 @@ impl BlobMetaChunkArray {
                 let entry = Self::get_chunk_entry(state, chunk_info_array, index - 1)?;
                 if !entry.is_zran() {
                     // All chunks should be ZRan chunks.
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
+                    return Err(std::io::Error::other(
                         "invalid ZRan compression information data",
                     ));
                 } else if entry.get_zran_index()? != first_zran_idx {
@@ -1746,8 +1745,7 @@ impl BlobMetaChunkArray {
 
             for entry in &chunk_info_array[index..] {
                 if entry.validate(state).is_err() || !entry.is_zran() {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::Other,
+                    return Err(std::io::Error::other(
                         "invalid ZRan compression information data",
                     ));
                 } else if entry.get_zran_index()? > last_zran_idx {

--- a/storage/src/meta/toc.rs
+++ b/storage/src/meta/toc.rs
@@ -460,41 +460,28 @@ impl TocEntryList {
         let header = Header::from_byte_slice(&buf[size..]);
         let entry_type = header.entry_type();
         if entry_type != EntryType::Regular {
-            return Err(Error::new(
-                ErrorKind::Other,
-                "Tar entry type for ToC is not a regular file",
-            ));
+            return Err(Error::other("Tar entry type for ToC is not a regular file"));
         }
-        let entry_size = header.entry_size().map_err(|_| {
-            Error::new(ErrorKind::Other, "failed to get entry size from tar header")
-        })?;
+        let entry_size = header
+            .entry_size()
+            .map_err(|_| Error::other("failed to get entry size from tar header"))?;
         if entry_size > size as u64 {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!(
-                    "invalid toc entry size in tar header, expect {}, got {}",
-                    size, entry_size
-                ),
-            ));
+            return Err(Error::other(format!(
+                "invalid toc entry size in tar header, expect {size}, got {entry_size}",
+            )));
         }
-        let name = header.path().map_err(|_| {
-            Error::new(
-                ErrorKind::Other,
-                "failed to get ToC file name from tar header",
-            )
-        })?;
+        let name = header
+            .path()
+            .map_err(|_| Error::other("failed to get ToC file name from tar header"))?;
         if name != Path::new(TOC_ENTRY_BLOB_TOC) {
-            return Err(Error::new(
-                ErrorKind::Other,
-                format!(
-                    "ToC file name from tar header doesn't match, {}",
-                    name.display()
-                ),
-            ));
+            return Err(Error::other(format!(
+                "ToC file name from tar header doesn't match, {}",
+                name.display()
+            )));
         }
         let _header = header
             .as_gnu()
-            .ok_or_else(|| Error::new(ErrorKind::Other, "invalid GNU tar header for ToC"))?;
+            .ok_or_else(|| Error::other("invalid GNU tar header for ToC"))?;
 
         let mut pos = size - entry_size as usize;
         let mut list = TocEntryList::new();

--- a/upgrade/src/persist.rs
+++ b/upgrade/src/persist.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;
-use std::io::{Error as IoError, ErrorKind, Result};
+use std::io::{Error as IoError, Result};
 use std::{any::TypeId, collections::HashMap};
 
 use dbs_snapshot::Snapshot;
@@ -44,12 +44,9 @@ pub trait Snapshotter: Versionize + Sized + Debug {
     fn save(&self) -> Result<Vec<u8>> {
         let mut buf = Vec::new();
         let mut snapshot = Self::new_snapshot();
-        snapshot.save(&mut buf, self).map_err(|e| {
-            IoError::new(
-                ErrorKind::Other,
-                format!("Failed to save snapshot: {:?}", e),
-            )
-        })?;
+        snapshot
+            .save(&mut buf, self)
+            .map_err(|e| IoError::other(format!("Failed to save snapshot: {e:?}")))?;
 
         Ok(buf)
     }
@@ -58,10 +55,7 @@ pub trait Snapshotter: Versionize + Sized + Debug {
     fn restore(buf: &mut Vec<u8>) -> Result<Self> {
         match Snapshot::load(&mut buf.as_slice(), buf.len(), Self::new_version_map()) {
             Ok((o, _)) => Ok(o),
-            Err(e) => Err(IoError::new(
-                ErrorKind::Other,
-                format!("Failed to load snapshot: {:?}", e),
-            )),
+            Err(e) => Err(IoError::other(format!("Failed to load snapshot: {e:?}"))),
         }
     }
 }

--- a/utils/src/compress/mod.rs
+++ b/utils/src/compress/mod.rs
@@ -35,7 +35,7 @@ impl fmt::Display for Algorithm {
             Algorithm::GZip => "gzip",
             Algorithm::Zstd => "zstd",
         };
-        write!(f, "{}", output)
+        write!(f, "{output}")
     }
 }
 
@@ -632,7 +632,7 @@ mod tests {
         for algo in algorithms {
             let stringified = algo.to_string();
             let parsed = Algorithm::from_str(&stringified).unwrap();
-            assert_eq!(algo, parsed, "Mismatch for algorithm: {:?}", algo);
+            assert_eq!(algo, parsed, "Mismatch for algorithm: {algo:?}");
         }
     }
 

--- a/utils/src/compress/zlib_random.rs
+++ b/utils/src/compress/zlib_random.rs
@@ -189,10 +189,10 @@ impl ZranDecoder {
 /// 1) create a `ZranGenerator` object `zran`.
 /// 2) create a tar::Archive object from `zran`.
 /// 3) walk all entries in the tarball, for each tar regular file:
-///     3.1) get file size and split it into chunks, for each file data chunk
-///     3.2) call zran.begin_data_chunk()
-///     3.3) read file content from the tar Entry object
-///     3.4) call zran.end_data_chunk() to get chunk decompression information
+///    3.1) get file size and split it into chunks, for each file data chunk
+///    3.2) call zran.begin_data_chunk()
+///    3.3) read file content from the tar Entry object
+///    3.4) call zran.end_data_chunk() to get chunk decompression information
 /// 4) call zran.get_compression_info_array() to get all decompression context information for
 ///    random access later
 pub struct ZranGenerator<R> {
@@ -607,7 +607,7 @@ impl ZranStream {
     fn get_compression_info(&mut self, buf: &[u8], stream_switched: u8) -> ZranCompInfo {
         let previous_byte = if self.stream.data_type & 0x7 != 0 {
             assert!(self.stream.next_in as usize >= buf.as_ptr() as usize);
-            if self.stream.next_in as usize == buf.as_ptr() as usize {
+            if std::ptr::eq(self.stream.next_in, buf.as_ptr()) {
                 self.last_byte
             } else {
                 unsafe { *self.stream.next_in.sub(1) }

--- a/utils/src/crc32.rs
+++ b/utils/src/crc32.rs
@@ -18,7 +18,7 @@ pub enum Algorithm {
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/utils/src/crypt.rs
+++ b/utils/src/crypt.rs
@@ -109,7 +109,7 @@ impl Algorithm {
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -735,7 +735,7 @@ mod tests {
         assert!(Algorithm::try_from(Algorithm::Aes256Gcm as u64).is_ok());
         assert!(Algorithm::try_from(u64::MAX).is_err());
 
-        println!("{:?},{:?},{:?},{:?}", none, aes128xts, aes256xts, aes256gcm);
+        println!("{none:?},{aes128xts:?},{aes256xts:?},{aes256gcm:?}");
     }
 
     #[test]

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -29,7 +29,7 @@ pub enum Algorithm {
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -217,7 +217,7 @@ impl AsRef<[u8]> for RafsDigest {
 impl fmt::Display for RafsDigest {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for c in &self.data {
-            write!(f, "{:02x}", c)?;
+            write!(f, "{c:02x}")?;
         }
         Ok(())
     }
@@ -225,7 +225,7 @@ impl fmt::Display for RafsDigest {
 
 impl From<RafsDigest> for String {
     fn from(d: RafsDigest) -> Self {
-        format!("{}", d)
+        format!("{d}")
     }
 }
 
@@ -331,7 +331,7 @@ mod test {
         let d2 = RafsDigest::from(d1.data);
         let s1: String = d1.into();
         let s2: String = d2.into();
-        print!("{:?}", d1);
+        print!("{d1:?}");
         assert_eq!(s1, s2);
         print!("{:?}, {:?}", Algorithm::Blake3, Algorithm::Sha256);
     }

--- a/utils/src/trace.rs
+++ b/utils/src/trace.rs
@@ -314,7 +314,7 @@ pub mod tests {
         let t1 = thread::Builder::new()
             .spawn(move || {
                 for i in 0..100 {
-                    timing_tracer!({ f() }, format!("t1.{}", i).as_str());
+                    timing_tracer!({ f() }, format!("t1.{i}").as_str());
                 }
             })
             .unwrap();
@@ -322,14 +322,14 @@ pub mod tests {
         let t2 = thread::Builder::new()
             .spawn(move || {
                 for i in 0..100 {
-                    timing_tracer!({ f() }, format!("t2.{}", i).as_str());
+                    timing_tracer!({ f() }, format!("t2.{i}").as_str());
                 }
             })
             .unwrap();
         let t3 = thread::Builder::new()
             .spawn(move || {
                 for i in 0..100 {
-                    timing_tracer!({ f() }, format!("t3.{}", i).as_str());
+                    timing_tracer!({ f() }, format!("t3.{i}").as_str());
                 }
             })
             .unwrap();


### PR DESCRIPTION
In preparation of using aws-sdk libraries which require Rust 1.88.
Fixes for clippy rule changes.