### PR TITLE
nydusd: conf validate merging_size to be pow of 2

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -680,6 +680,9 @@ impl CacheConfigV2 {
             if self.prefetch.batch_size > 0x10000000 {
                 return false;
             }
+            if !self.prefetch.batch_size.is_power_of_two() {
+                return false;
+            }
             if self.prefetch.threads_count == 0 || self.prefetch.threads_count > 1024 {
                 return false;
             }
@@ -2319,6 +2322,19 @@ mod tests {
 
         let cfg = CacheConfigV2 {
             cache_type: "foobar".to_string(),
+            ..Default::default()
+        };
+        assert!(!cfg.validate());
+
+        let cfg = CacheConfigV2 {
+            cache_type: "dummycache".to_string(),
+            prefetch: PrefetchConfigV2 {
+                enable: true,
+                threads_count: 1,
+                batch_size: 1023, // not power of two
+                bandwidth_limit: 10000000,
+                prefetch_all: false,
+            },
             ..Default::default()
         };
         assert!(!cfg.validate());


### PR DESCRIPTION
## Details
fs_prefetch.merging_size must be a power of two.
An assert deep in the prefetch code checks this.

Add a check in configuration validation.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.