### PR TITLE
nydusd: PersistMap v2

### DIFF
--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -47,6 +47,7 @@ tokio = { version = "1.19.0", features = [
 ] }
 url = { version = "2.1.1", optional = true }
 vm-memory = { workspace = true }
+vmm-sys-util = { workspace = true }
 fuse-backend-rs = { workspace = true }
 gpt = { version = "3.1.0", optional = true }
 
@@ -62,7 +63,6 @@ aws-credential-types = "1.2.11"
 
 [dev-dependencies]
 hyper-util = { version = "0.1.19", features = ["server"] }
-vmm-sys-util = { workspace = true }
 tar = "0.4.40"
 regex = "1.7.0"
 toml = "0.5"

--- a/storage/src/cache/state/indexed_chunk_map.rs
+++ b/storage/src/cache/state/indexed_chunk_map.rs
@@ -35,9 +35,14 @@ pub struct IndexedChunkMap {
 impl IndexedChunkMap {
     /// Create a new instance of `IndexedChunkMap`.
     pub fn new(blob_path: &str, chunk_count: u32, persist: bool) -> Result<Self> {
-        let filename = format!("{blob_path}.{FILE_SUFFIX}");
+        let map = if persist {
+            let filename = format!("{blob_path}.{FILE_SUFFIX}");
+            PersistMap::create(&filename, chunk_count)?
+        } else {
+            PersistMap::transient(chunk_count)?
+        };
 
-        PersistMap::open(&filename, chunk_count, true, persist).map(|map| IndexedChunkMap { map })
+        Ok(Self { map })
     }
 }
 
@@ -46,8 +51,7 @@ impl ChunkMap for IndexedChunkMap {
         if self.is_range_all_ready() {
             Ok(true)
         } else {
-            let index = self.map.validate_index(chunk.id())?;
-            Ok(self.map.is_chunk_ready(index).0)
+            self.map.is_chunk_ready(chunk.id())
         }
     }
 
@@ -75,10 +79,9 @@ impl RangeMap for IndexedChunkMap {
     fn is_range_ready(&self, start_index: u32, count: u32) -> Result<bool> {
         if !self.is_range_all_ready() {
             for idx in 0..count {
-                let index = self
-                    .map
-                    .validate_index(start_index.checked_add(idx).ok_or_else(|| einval!())?)?;
-                if !self.map.is_chunk_ready(index).0 {
+                let index = start_index.checked_add(idx).ok_or_else(|| einval!())?;
+
+                if !self.map.is_chunk_ready(index)? {
                     return Ok(false);
                 }
             }
@@ -101,7 +104,7 @@ impl RangeMap for IndexedChunkMap {
         let end = start_index + count;
 
         for index in start_index..end {
-            if !self.map.is_chunk_ready(index).0 {
+            if !self.map.is_chunk_ready(index)? {
                 vec.push(index);
             }
         }
@@ -137,7 +140,7 @@ impl ChunkIndexGetter for IndexedChunkMap {
 mod tests {
     use std::fs::OpenOptions;
     use std::io::Write;
-    use std::sync::atomic::Ordering;
+    use std::sync::atomic::AtomicU32;
     use vmm_sys_util::tempdir::TempDir;
 
     use super::super::persist_map::*;
@@ -175,79 +178,6 @@ mod tests {
     }
 
     #[test]
-    fn test_indexed_new_zero_file_size() {
-        let dir = TempDir::new().unwrap();
-        let blob_path = dir.as_path().join("blob-1");
-        let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
-
-        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
-
-        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
-        let _file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&cache_path)
-            .map_err(|err| {
-                einval!(format!(
-                    "failed to open/create blob chunk_map file {:?}: {:?}",
-                    cache_path, err
-                ))
-            })
-            .unwrap();
-
-        let chunk = MockChunkInfo::new();
-        assert_eq!(chunk.id(), 0);
-
-        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
-        assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
-        assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size(), 0x1001);
-        assert!(!map.is_range_all_ready());
-        assert!(!map.is_ready(chunk.as_base()).unwrap());
-        map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
-        assert!(map.is_ready(chunk.as_base()).unwrap());
-    }
-
-    #[test]
-    fn test_indexed_new_header_not_ready() {
-        let dir = TempDir::new().unwrap();
-        let blob_path = dir.as_path().join("blob-1");
-        let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
-
-        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
-
-        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&cache_path)
-            .map_err(|err| {
-                einval!(format!(
-                    "failed to open/create blob chunk_map file {:?}: {:?}",
-                    cache_path, err
-                ))
-            })
-            .unwrap();
-        file.set_len(0x1001).unwrap();
-
-        let chunk = MockChunkInfo::new();
-        assert_eq!(chunk.id(), 0);
-
-        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
-        assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
-        assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size(), 0x1001);
-        assert!(!map.is_range_all_ready());
-        assert!(!map.is_ready(chunk.as_base()).unwrap());
-        map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
-        assert!(map.is_ready(chunk.as_base()).unwrap());
-    }
-
-    #[test]
     fn test_indexed_new_all_ready() {
         let dir = TempDir::new().unwrap();
         let blob_path = dir.as_path().join("blob-1");
@@ -271,9 +201,11 @@ mod tests {
             .unwrap();
         let header = Header {
             magic: MAGIC1,
-            version: 1,
+            version: 2,
             magic2: MAGIC2,
-            all_ready: MAGIC_ALL_READY,
+            _all_ready: 0,
+            count: 1,
+            not_ready_count: AtomicU32::new(0),
             reserved: [0x0u8; HEADER_RESERVED_SIZE],
         };
 
@@ -286,56 +218,9 @@ mod tests {
 
         let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert!(map.is_range_all_ready());
-        assert_eq!(map.map.count, 1);
+        assert_eq!(map.map.count(), 1);
         assert_eq!(map.map.size(), 0x1001);
         assert!(map.is_ready(chunk.as_base()).unwrap());
-        map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
-        assert!(map.is_ready(chunk.as_base()).unwrap());
-    }
-
-    #[test]
-    fn test_indexed_new_load_v0() {
-        let dir = TempDir::new().unwrap();
-        let blob_path = dir.as_path().join("blob-1");
-        let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
-
-        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
-
-        let cache_path = format!("{blob_path}.{FILE_SUFFIX}");
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&cache_path)
-            .map_err(|err| {
-                einval!(format!(
-                    "failed to open/create blob chunk_map file {:?}: {:?}",
-                    cache_path, err
-                ))
-            })
-            .unwrap();
-        let header = Header {
-            magic: MAGIC1,
-            version: 0,
-            magic2: 0,
-            all_ready: 0,
-            reserved: [0x0u8; HEADER_RESERVED_SIZE],
-        };
-
-        // write file header and sync to disk.
-        file.write_all(header.as_slice()).unwrap();
-        file.write_all(&[0x0u8]).unwrap();
-
-        let chunk = MockChunkInfo::new();
-        assert_eq!(chunk.id(), 0);
-
-        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
-        assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
-        assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size(), 0x1001);
-        assert!(!map.is_range_all_ready());
-        assert!(!map.is_ready(chunk.as_base()).unwrap());
         map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
         assert!(map.is_ready(chunk.as_base()).unwrap());
     }

--- a/storage/src/cache/state/persist_map.rs
+++ b/storage/src/cache/state/persist_map.rs
@@ -4,20 +4,26 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::{File, OpenOptions};
-use std::io::{Result, Write};
+use std::io::Result;
+use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU32, AtomicU8, Ordering};
 
+use nix::NixPath;
 use nydus_utils::div_round_up;
-use nydus_utils::filemap::{clone_file, FileMapState};
+use nydus_utils::filemap::FileMapState;
 
 use crate::utils::readahead;
 
+#[cfg(target_os = "macos")]
+use vmm_sys_util::tempfile::TempFile;
+
+pub(crate) const VERSION: u32 = 2;
 pub(crate) const MAGIC1: u32 = 0x424D_4150;
 pub(crate) const MAGIC2: u32 = 0x434D_4150;
-pub(crate) const MAGIC_ALL_READY: u32 = 0x4D4D_4150;
 pub(crate) const HEADER_SIZE: usize = 4096;
-pub(crate) const HEADER_RESERVED_SIZE: usize = HEADER_SIZE - 16;
+pub(crate) const HEADER_RESERVED_SIZE: usize = HEADER_SIZE - 20 - size_of::<AtomicU32>();
 
 /// The blob chunk map file header, 4096 bytes.
 #[repr(C)]
@@ -26,11 +32,14 @@ pub(crate) struct Header {
     pub magic: u32,
     pub version: u32,
     pub magic2: u32,
-    pub all_ready: u32,
+    pub _all_ready: u32,
+    pub count: u32,
+    pub not_ready_count: AtomicU32,
     pub reserved: [u8; HEADER_RESERVED_SIZE],
 }
 
 impl Header {
+    #[cfg(test)]
     pub fn as_slice(&self) -> &[u8] {
         unsafe {
             std::slice::from_raw_parts(
@@ -42,133 +51,150 @@ impl Header {
 }
 
 pub(crate) struct PersistMap {
-    pub count: u32,
-    pub not_ready_count: AtomicU32,
+    count: u32,
     filemap: FileMapState,
 }
 
 impl PersistMap {
-    pub fn open(filename: &str, chunk_count: u32, create: bool, persist: bool) -> Result<Self> {
+    /// Creates a new file or opens existing. An existing file chunk count must
+    /// match the specified.
+    pub fn create<P: AsRef<Path>>(filename: P, chunk_count: u32) -> Result<Self> {
         if chunk_count == 0 {
             return Err(einval!("chunk count should be greater than 0"));
         }
 
-        let mut file = OpenOptions::new()
-            .read(true)
-            .write(create)
-            .create(create)
-            .truncate(!persist)
-            .open(filename)
-            .map_err(|err| {
-                einval!(format!(
-                    "failed to open/create blob chunk_map file {:?}: {:?}",
-                    filename, err
-                ))
-            })?;
-
-        let file_size = file.metadata()?.len();
-        let bitmap_size = div_round_up(chunk_count as u64, 8u64);
-        let expected_size = HEADER_SIZE as u64 + bitmap_size;
-        let mut new_content = false;
-
-        if file_size == 0 {
-            if !create {
-                return Err(enoent!());
-            }
-
-            new_content = true;
-            Self::write_header(&mut file, expected_size)?;
-        } else if file_size != expected_size {
-            // File size doesn't match, it's too risky to accept the chunk state file. Fallback to
-            // always mark chunk data as not ready.
-            warn!("blob chunk_map file may be corrupted: {:?}", filename);
-            return Err(einval!(format!("chunk_map file {:?} is invalid", filename)));
-        }
-
-        let file2 = clone_file(file.as_raw_fd())?;
-        let mut filemap = FileMapState::new(file2, 0, expected_size as usize, true)?;
-        let header = filemap.get_mut::<Header>(0)?;
-        if header.magic != MAGIC1 {
-            if !create {
-                return Err(enoent!());
-            }
-
-            // There's race window between "file.set_len()" and "file.write(&header)". If that
-            // happens, all file content should be zero. Detect the race window and write out
-            // header again to fix it.
-            let content = filemap.get_slice::<u8>(0, expected_size as usize)?;
-            for c in content {
-                if *c != 0 {
-                    return Err(einval!(format!(
-                        "invalid blob chunk_map file header: {:?}",
-                        filename
-                    )));
-                }
-            }
-
-            new_content = true;
-            Self::write_header(&mut file, expected_size)?;
-        }
-
-        let header = filemap.get_mut::<Header>(0)?;
-        let mut not_ready_count = chunk_count;
-        if header.version >= 1 {
-            if header.magic2 != MAGIC2 {
-                return Err(einval!(format!(
-                    "invalid blob chunk_map file header: {:?}",
-                    filename
-                )));
-            }
-            if header.all_ready == MAGIC_ALL_READY {
-                not_ready_count = 0;
-            } else if new_content {
-                not_ready_count = chunk_count;
-            } else {
-                let mut ready_count = 0;
-                for idx in HEADER_SIZE..expected_size as usize {
-                    let current = filemap.get_ref::<AtomicU8>(idx)?;
-                    let val = current.load(Ordering::Acquire);
-                    ready_count += val.count_ones() as u32;
-                }
-
-                if ready_count >= chunk_count {
-                    let header = filemap.get_mut::<Header>(0)?;
-                    header.all_ready = MAGIC_ALL_READY;
-                    let _ = file.sync_all();
-                    not_ready_count = 0;
+        let filename = filename.as_ref();
+        let dir = filename
+            .parent()
+            .map(|d| {
+                if d.is_empty() {
+                    PathBuf::from(".")
                 } else {
-                    not_ready_count = chunk_count - ready_count;
+                    d.into()
                 }
+            })
+            .ok_or_else(|| einval!("missing filename"))?;
+
+        // Create an annonymous file
+        let file = AnonymousFile::open(&dir)?;
+
+        let file_size = Self::calc_file_size(chunk_count);
+        file.inner().set_len(file_size)?;
+
+        let mut filemap =
+            FileMapState::new(file.inner().try_clone()?, 0, file_size as usize, true)?;
+
+        // Write the header and zeroed out bitmap
+        Self::write_header(&mut filemap, chunk_count)?;
+
+        // Flush before publishing to ensure that the file is in a valid state on disk
+        file.inner().sync_all()?;
+
+        // Publish as filename
+        match file.publish(&filename) {
+            Ok(()) => Ok(Self {
+                count: chunk_count,
+                filemap,
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // Another process beat us to it
+                Self::existing(filename, chunk_count)
             }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Akin to `create` but does not store it on disk.
+    pub fn transient(chunk_count: u32) -> Result<Self> {
+        if chunk_count == 0 {
+            return Err(einval!("chunk count should be greater than 0"));
         }
 
-        readahead(file.as_raw_fd(), 0, expected_size);
-        if !persist {
-            let _ = std::fs::remove_file(filename);
-        }
+        let file_size = Self::calc_file_size(chunk_count);
+
+        let mut filemap = FileMapState::anonymous(0, file_size as usize)?;
+
+        // Write the header and zeroed out bitmap
+        Self::write_header(&mut filemap, chunk_count)?;
 
         Ok(Self {
             count: chunk_count,
-            not_ready_count: AtomicU32::new(not_ready_count),
             filemap,
         })
     }
 
-    fn write_header(file: &mut File, size: u64) -> Result<()> {
+    /// Opens an existing file. Fails if the file does not exist.
+    /// An existing file chunk count must match the specified.
+    pub fn existing<P: AsRef<Path>>(filename: P, chunk_count: u32) -> Result<Self> {
+        if chunk_count == 0 {
+            return Err(einval!("chunk count should be greater than 0"));
+        }
+
+        let filename = filename.as_ref();
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(filename)
+            .map_err(|err| {
+                einval!(format!(
+                    "failed to open blob chunk_map file {}: {err}",
+                    filename.display()
+                ))
+            })?;
+
+        let file_size = file.metadata()?.len();
+        let expected_size = Self::calc_file_size(chunk_count);
+        if file_size != expected_size {
+            return Err(einval!(format!(
+                "chunk_map file {} has unexpected size: {file_size}, expected: {expected_size}",
+                filename.display()
+            )));
+        }
+
+        readahead(file.as_raw_fd(), 0, expected_size);
+
+        let mut filemap = FileMapState::new(file, 0, expected_size as usize, true)?;
+        let header = filemap.get_mut::<Header>(0)?;
+        if header.magic != MAGIC1 {
+            return Err(einval!(format!(
+                "chunk_map file {filename:?} has bad magic"
+            )));
+        }
+        if header.version != VERSION {
+            return Err(einval!(format!(
+                "chunk_map file {filename:?} has bad version"
+            )));
+        }
+        if header.count != chunk_count {
+            return Err(einval!(format!(
+                "chunk_map file {filename:?} has wrong count"
+            )));
+        }
+
+        Ok(Self {
+            count: chunk_count,
+            filemap,
+        })
+    }
+
+    fn calc_file_size(chunk_count: u32) -> u64 {
+        let bitmap_size = div_round_up(chunk_count as u64, 8u64);
+        HEADER_SIZE as u64 + bitmap_size
+    }
+
+    fn write_header(filemap: &mut FileMapState, chunk_count: u32) -> Result<()> {
         let header = Header {
             magic: MAGIC1,
-            version: 1,
+            version: VERSION,
             magic2: MAGIC2,
-            all_ready: 0,
+            _all_ready: 0,
+            count: chunk_count,
+            not_ready_count: AtomicU32::new(chunk_count),
             reserved: [0x0u8; HEADER_RESERVED_SIZE],
         };
 
-        // Set file size to expected value and sync to disk.
-        file.set_len(size)?;
-        file.sync_all()?;
-        // write file header and sync to disk.
-        file.write_all(header.as_slice())?;
-        file.sync_all()?;
+        *filemap.get_mut(0)? = header;
 
         Ok(())
     }
@@ -179,9 +205,9 @@ impl PersistMap {
     }
 
     #[inline]
-    pub fn validate_index(&self, idx: u32) -> Result<u32> {
+    fn validate_index(&self, idx: u32) -> Result<()> {
         if idx < self.count {
-            Ok(idx)
+            Ok(())
         } else {
             Err(einval!(format!(
                 "chunk index {} exceeds chunk count {}",
@@ -191,23 +217,23 @@ impl PersistMap {
     }
 
     #[inline]
-    fn read_u8(&self, idx: u32) -> u8 {
+    fn read_u8(&self, idx: u32) -> Result<u8> {
         let start = HEADER_SIZE + (idx as usize >> 3);
-        let current = self.filemap.get_ref::<AtomicU8>(start).unwrap();
+        let current = self.filemap.get_ref::<AtomicU8>(start)?;
 
-        current.load(Ordering::Acquire)
+        Ok(current.load(Ordering::Acquire))
     }
 
     #[inline]
-    fn write_u8(&self, idx: u32, current: u8) -> bool {
+    fn write_u8(&self, idx: u32, current: u8) -> Result<bool> {
         let mask = Self::index_to_mask(idx);
         let expected = current | mask;
         let start = HEADER_SIZE + (idx as usize >> 3);
-        let atomic_value = self.filemap.get_ref::<AtomicU8>(start).unwrap();
+        let atomic_value = self.filemap.get_ref::<AtomicU8>(start)?;
 
-        atomic_value
+        Ok(atomic_value
             .compare_exchange(current, expected, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok()
+            .is_ok())
     }
 
     #[inline]
@@ -217,28 +243,33 @@ impl PersistMap {
     }
 
     #[inline]
-    pub fn is_chunk_ready(&self, index: u32) -> (bool, u8) {
-        let mask = Self::index_to_mask(index);
-        let current = self.read_u8(index);
-        let ready = current & mask == mask;
+    fn header(&self) -> &Header {
+        self.filemap.get_ref(0).unwrap()
+    }
 
-        (ready, current)
+    #[inline]
+    pub fn is_chunk_ready(&self, index: u32) -> Result<bool> {
+        self.validate_index(index)?;
+
+        let mask = Self::index_to_mask(index);
+        let current = self.read_u8(index)?;
+        Ok(current & mask == mask)
     }
 
     pub fn set_chunk_ready(&self, index: u32) -> Result<()> {
-        let index = self.validate_index(index)?;
+        self.validate_index(index)?;
+        let mask = Self::index_to_mask(index);
 
         // Loop to atomically update the state bit corresponding to the chunk index.
         loop {
-            let (ready, current) = self.is_chunk_ready(index);
+            let current = self.read_u8(index)?;
+            let ready = current & mask == mask;
             if ready {
                 break;
             }
 
-            if self.write_u8(index, current) {
-                if self.not_ready_count.fetch_sub(1, Ordering::AcqRel) == 1 {
-                    self.mark_all_ready();
-                }
+            if self.write_u8(index, current)? {
+                self.header().not_ready_count.fetch_sub(1, Ordering::AcqRel);
                 break;
             }
         }
@@ -246,19 +277,135 @@ impl PersistMap {
         Ok(())
     }
 
-    fn mark_all_ready(&self) {
-        if self.filemap.sync_data().is_ok() {
-            /*
-            if let Ok(header) = self.filemap.get_mut::<Header>(0) {
-                header.all_ready = MAGIC_ALL_READY;
-                let _ = self.filemap.sync_data();
-            }
-             */
-        }
+    #[inline]
+    pub fn is_range_all_ready(&self) -> bool {
+        self.header().not_ready_count.load(Ordering::Acquire) == 0
     }
 
     #[inline]
-    pub fn is_range_all_ready(&self) -> bool {
-        self.not_ready_count.load(Ordering::Acquire) == 0
+    #[cfg(test)]
+    pub fn count(&self) -> u32 {
+        self.count
+    }
+}
+
+#[cfg(target_os = "macos")]
+struct AnonymousFile(TempFile);
+
+#[cfg(target_os = "macos")]
+impl AnonymousFile {
+    fn open(dir: &Path) -> Result<Self> {
+        Ok(Self(TempFile::new_in(dir)?))
+    }
+
+    fn inner(&self) -> &File {
+        &self.0.as_file()
+    }
+
+    fn publish(&self, filename: &Path) -> Result<()> {
+        fs::hard_link(self.0.as_path(), filename)
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct AnonymousFile(File);
+
+#[cfg(target_os = "linux")]
+impl AnonymousFile {
+    fn open(dir: &Path) -> Result<Self> {
+        // Create an annonymous file
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .custom_flags(libc::O_TMPFILE)
+            .open(dir)
+            .map_err(|err| einval!(format!("failed to open/create blob chunk_map file: {err}",)))?;
+
+        Ok(Self(file))
+    }
+
+    fn inner(&self) -> &File {
+        &self.0
+    }
+
+    fn publish(&self, filename: &Path) -> Result<()> {
+        let ret = unsafe {
+            let oldpath = std::ffi::CString::default();
+            let newpath = std::ffi::CString::new(filename.as_os_str().as_encoded_bytes())?;
+
+            libc::linkat(
+                self.0.as_raw_fd(),
+                oldpath.as_ptr(),
+                libc::AT_FDCWD,
+                newpath.as_ptr(),
+                libc::AT_EMPTY_PATH,
+            )
+        };
+
+        if ret < 0 {
+            Err(last_error!())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmm_sys_util::tempdir::TempDir;
+
+    const NUM_CHUNKS: u32 = 1000;
+
+    #[test]
+    fn test_persist_map_create() {
+        let dir = TempDir::new().unwrap();
+        let filename = dir.as_path().join("persist-map");
+
+        let mut maps: Vec<PersistMap> = Vec::new();
+
+        for i in 0..10 {
+            let map = PersistMap::create(&filename, NUM_CHUNKS).unwrap();
+            assert!(map.count() == NUM_CHUNKS);
+
+            // set some ready with overlap from the previous iteration
+            let start_idx = std::cmp::max((i as i32) * 100 - 20, 0) as u32;
+            let end_idx = (i + 1) * 100;
+            for idx in start_idx..end_idx {
+                map.set_chunk_ready(idx as u32).unwrap();
+                assert!(map.is_chunk_ready(idx).unwrap());
+
+                let is_last = idx == NUM_CHUNKS - 1;
+                assert!(map.is_range_all_ready() == is_last);
+            }
+
+            maps.push(map);
+        }
+
+        // close all
+        drop(maps);
+
+        // make sure the file is still there
+        let map = PersistMap::create(&filename, NUM_CHUNKS).unwrap();
+        assert!(map.is_range_all_ready());
+        drop(map);
+
+        let map = PersistMap::existing(&filename, NUM_CHUNKS).unwrap();
+        assert!(map.is_range_all_ready());
+    }
+
+    #[test]
+    fn test_persist_map_transient() {
+        let map = PersistMap::transient(NUM_CHUNKS).unwrap();
+        assert!(map.count() == NUM_CHUNKS);
+
+        // set some ready with overlap from the previous iteration
+        for idx in 0..NUM_CHUNKS {
+            map.set_chunk_ready(idx as u32).unwrap();
+            assert!(map.is_chunk_ready(idx).unwrap());
+
+            let is_last = idx == NUM_CHUNKS - 1;
+            assert!(map.is_range_all_ready() == is_last);
+        }
     }
 }

--- a/storage/src/cache/state/range_map.rs
+++ b/storage/src/cache/state/range_map.rs
@@ -28,7 +28,7 @@ impl BlobRangeMap {
         let filename = format!("{blob_path}.{FILE_SUFFIX}");
         debug_assert!(shift < 64);
 
-        PersistMap::open(&filename, count, true, true).map(|map| BlobRangeMap { shift, map })
+        PersistMap::create(&filename, count).map(|map| BlobRangeMap { shift, map })
     }
 
     /// Create a new instance of `BlobRangeMap` from an existing chunk map file.
@@ -36,7 +36,7 @@ impl BlobRangeMap {
         let filename = format!("{workdir}/{blob_id}.{FILE_SUFFIX}");
         debug_assert!(shift < 64);
 
-        PersistMap::open(&filename, count, false, true).map(|map| BlobRangeMap { shift, map })
+        PersistMap::existing(&filename, count).map(|map| BlobRangeMap { shift, map })
     }
 
     pub(crate) fn get_range(&self, start: u64, count: u64) -> Result<(u32, u32)> {
@@ -46,8 +46,6 @@ impl BlobRangeMap {
             if start_index > u32::MAX as u64 || end_index > u32::MAX as u64 {
                 Err(einval!())
             } else {
-                self.map.validate_index(start_index as u32)?;
-                self.map.validate_index(end_index as u32)?;
                 Ok((start_index as u32, end_index as u32 + 1))
             }
         } else {
@@ -68,7 +66,7 @@ impl RangeMap for BlobRangeMap {
         if !self.is_range_all_ready() {
             let (start_index, end_index) = self.get_range(start, count)?;
             for index in start_index..end_index {
-                if !self.map.is_chunk_ready(index).0 {
+                if !self.map.is_chunk_ready(index)? {
                     return Ok(false);
                 }
             }
@@ -89,7 +87,7 @@ impl RangeMap for BlobRangeMap {
             let mut vec = Vec::with_capacity(count as usize);
 
             for index in start_index..end_index {
-                if !self.map.is_chunk_ready(index).0 {
+                if !self.map.is_chunk_ready(index)? {
                     vec.push((index as u64) << self.shift);
                 }
             }

--- a/utils/src/filemap.rs
+++ b/utils/src/filemap.rs
@@ -5,7 +5,7 @@
 use std::fs::File;
 use std::io::Result;
 use std::mem::size_of;
-use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 
 /// Struct to manage memory range mapped from file objects.
 ///
@@ -53,6 +53,20 @@ impl FileMapState {
     ///
     /// It takes ownership of the file object and will close it when the returned object is dropped.
     pub fn new(file: File, offset: libc::off_t, size: usize, writable: bool) -> Result<Self> {
+        Self::from_fd(file.into_raw_fd(), offset, size, writable, 0)
+    }
+
+    pub fn anonymous(offset: libc::off_t, size: usize) -> Result<Self> {
+        Self::from_fd(-1, offset, size, true, libc::MAP_ANONYMOUS)
+    }
+
+    fn from_fd(
+        fd: RawFd,
+        offset: libc::off_t,
+        size: usize,
+        writable: bool,
+        flags: libc::c_int,
+    ) -> Result<Self> {
         let prot = if writable {
             libc::PROT_READ | libc::PROT_WRITE
         } else {
@@ -63,8 +77,8 @@ impl FileMapState {
                 std::ptr::null_mut(),
                 size,
                 prot,
-                libc::MAP_NORESERVE | libc::MAP_SHARED,
-                file.as_raw_fd(),
+                libc::MAP_NORESERVE | libc::MAP_SHARED | flags,
+                fd,
                 offset,
             )
         } as *const u8;
@@ -81,7 +95,7 @@ impl FileMapState {
         let end = unsafe { base.add(size) };
 
         Ok(Self {
-            fd: file.into_raw_fd(),
+            fd,
             base,
             end,
             size,


### PR DESCRIPTION
## Details
- Avoids races by fully initializing an anonymous file and then attempting to publish it under the given name.
- Keeps track of not_ready_chunks in the file header so it can be shared between processes.
- *Not* backwards compat with previous versions. Will fail to open old files.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ X] I have added tests to cover my changes.